### PR TITLE
2016 U.S. Presidental Party Vote By State

### DIFF
--- a/lab3/scripts/make_pres.py
+++ b/lab3/scripts/make_pres.py
@@ -1,0 +1,30 @@
+import csv
+
+states = {}
+rows = []
+with open("pres.csv","r") as csvfile:
+    spam = csv.reader(csvfile, delimiter=",")
+    for i,row in enumerate(spam):
+        if i == 0:
+            continue
+        if row[0] != "2016":
+            continue
+
+        party = row[8]
+        if party == "democrat":
+            party = "D"
+        elif party == "republican":
+            party = "R"
+        else:
+            party = "I"
+        percent_vote = str(round(float(row[10])/float(row[11])*100,2))
+        if row[1] not in states:
+            states[row[1]] = True
+            rows.append([row[0],row[1],party, percent_vote])
+    
+with open("pres_2016.csv","w") as csvfile:
+    csvfile.write(",".join(["year","state","party","percent_vote","\n"]))
+    for row in rows:
+        csvfile.write(",".join(row)+"\n")
+
+

--- a/lab3/scripts/pres.csv
+++ b/lab3/scripts/pres.csv
@@ -1,0 +1,3741 @@
+"year","state","state_po","state_fips","state_cen","state_ic","office","candidate","party","writein","candidatevotes","totalvotes","version","notes"
+1976,"Alabama","AL",1,63,41,"US President","Carter, Jimmy","democrat",FALSE,659170,1182850,20171015,NA
+1976,"Alabama","AL",1,63,41,"US President","Ford, Gerald","republican",FALSE,504070,1182850,20171015,NA
+1976,"Alabama","AL",1,63,41,"US President","Maddox, Lester","american independent party",FALSE,9198,1182850,20171015,NA
+1976,"Alabama","AL",1,63,41,"US President","Bubar, Benjamin """"Ben""""","prohibition",FALSE,6669,1182850,20171015,NA
+1976,"Alabama","AL",1,63,41,"US President","Hall, Gus","communist party use",FALSE,1954,1182850,20171015,NA
+1976,"Alabama","AL",1,63,41,"US President","Macbride, Roger","libertarian",FALSE,1481,1182850,20171015,NA
+1976,"Alabama","AL",1,63,41,"US President","","",TRUE,308,1182850,20171015,NA
+1976,"Alaska","AK",2,94,81,"US President","Ford, Gerald","republican",FALSE,71555,123574,20171015,NA
+1976,"Alaska","AK",2,94,81,"US President","Carter, Jimmy","democrat",FALSE,44058,123574,20171015,NA
+1976,"Alaska","AK",2,94,81,"US President","Macbride, Roger","libertarian",FALSE,6785,123574,20171015,NA
+1976,"Alaska","AK",2,94,81,"US President","","",TRUE,1176,123574,20171015,NA
+1976,"Arizona","AZ",4,86,61,"US President","Ford, Gerald","republican",FALSE,418642,742719,20171015,NA
+1976,"Arizona","AZ",4,86,61,"US President","Carter, Jimmy","democrat",FALSE,295602,742719,20171015,NA
+1976,"Arizona","AZ",4,86,61,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,19229,742719,20171015,NA
+1976,"Arizona","AZ",4,86,61,"US President","Macbride, Roger","libertarian",FALSE,7647,742719,20171015,NA
+1976,"Arizona","AZ",4,86,61,"US President","Camejo, Peter","socialist workers",FALSE,928,742719,20171015,NA
+1976,"Arizona","AZ",4,86,61,"US President","Anderson, Thomas J.","american",FALSE,564,742719,20171015,NA
+1976,"Arizona","AZ",4,86,61,"US President","Maddox, Lester","american independent party",FALSE,85,742719,20171015,NA
+1976,"Arizona","AZ",4,86,61,"US President","","",TRUE,22,742719,20171015,NA
+1976,"Arkansas","AR",5,71,42,"US President","Carter, Jimmy","democrat",FALSE,498604,767535,20171015,NA
+1976,"Arkansas","AR",5,71,42,"US President","Ford, Gerald","republican",FALSE,267903,767535,20171015,NA
+1976,"Arkansas","AR",5,71,42,"US President","","independent",FALSE,639,767535,20171015,NA
+1976,"Arkansas","AR",5,71,42,"US President","Maddox, Lester","american independent party",FALSE,389,767535,20171015,NA
+1976,"California","CA",6,93,71,"US President","Ford, Gerald","republican",FALSE,3882244,7803770,20171015,NA
+1976,"California","CA",6,93,71,"US President","Carter, Jimmy","democrat",FALSE,3742284,7803770,20171015,NA
+1976,"California","CA",6,93,71,"US President","Macbride, Roger","independent",FALSE,56388,7803770,20171015,NA
+1976,"California","CA",6,93,71,"US President","Maddox, Lester","american independent party",FALSE,51098,7803770,20171015,NA
+1976,"California","CA",6,93,71,"US President","Wright, Margaret","peace & freedom",FALSE,41731,7803770,20171015,NA
+1976,"California","CA",6,93,71,"US President","Camejo, Peter","independent",FALSE,17259,7803770,20171015,NA
+1976,"California","CA",6,93,71,"US President","Hall, Gus","independent",FALSE,12766,7803770,20171015,NA
+1976,"Colorado","CO",8,84,62,"US President","Ford, Gerald","republican",FALSE,584278,1081440,20171015,NA
+1976,"Colorado","CO",8,84,62,"US President","Carter, Jimmy","democrat",FALSE,460801,1081440,20171015,NA
+1976,"Colorado","CO",8,84,62,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,26047,1081440,20171015,NA
+1976,"Colorado","CO",8,84,62,"US President","Macbride, Roger","libertarian",FALSE,5338,1081440,20171015,NA
+1976,"Colorado","CO",8,84,62,"US President","Bubar, Benjamin """"Ben""""","prohibition",FALSE,2886,1081440,20171015,NA
+1976,"Colorado","CO",8,84,62,"US President","Camejo, Peter","socialist workers",FALSE,1122,1081440,20171015,NA
+1976,"Colorado","CO",8,84,62,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,565,1081440,20171015,NA
+1976,"Colorado","CO",8,84,62,"US President","Hall, Gus","communist party use",FALSE,403,1081440,20171015,NA
+1976,"Connecticut","CT",9,16,1,"US President","Ford, Gerald","republican",FALSE,719261,1386355,20171015,NA
+1976,"Connecticut","CT",9,16,1,"US President","Carter, Jimmy","democrat",FALSE,647895,1386355,20171015,NA
+1976,"Connecticut","CT",9,16,1,"US President","Scattering","",FALSE,10309,1386355,20171015,NA
+1976,"Connecticut","CT",9,16,1,"US President","Maddox, Lester","american independent party",FALSE,7101,1386355,20171015,NA
+1976,"Connecticut","CT",9,16,1,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,1789,1386355,20171015,NA
+1976,"Delaware","DE",10,51,11,"US President","Carter, Jimmy","democrat",FALSE,122461,235642,20171015,NA
+1976,"Delaware","DE",10,51,11,"US President","Ford, Gerald","republican",FALSE,109780,235642,20171015,NA
+1976,"Delaware","DE",10,51,11,"US President","","no party affiliation",FALSE,2432,235642,20171015,NA
+1976,"Delaware","DE",10,51,11,"US President","Anderson, Thomas J.","american",FALSE,645,235642,20171015,NA
+1976,"Delaware","DE",10,51,11,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,135,235642,20171015,NA
+1976,"Delaware","DE",10,51,11,"US President","Bubar, Benjamin """"Ben""""","prohibition",FALSE,103,235642,20171015,NA
+1976,"Delaware","DE",10,51,11,"US President","","socialist labor",FALSE,86,235642,20171015,NA
+1976,"District of Columbia","DC",11,53,55,"US President","Carter, Jimmy","democrat",FALSE,137818,168830,20171015,NA
+1976,"District of Columbia","DC",11,53,55,"US President","Ford, Gerald","republican",FALSE,27873,168830,20171015,NA
+1976,"District of Columbia","DC",11,53,55,"US President","Other","",FALSE,1656,168830,20171015,NA
+1976,"District of Columbia","DC",11,53,55,"US President","","independent",FALSE,1195,168830,20171015,NA
+1976,"District of Columbia","DC",11,53,55,"US President","","",TRUE,288,168830,20171015,NA
+1976,"Florida","FL",12,59,43,"US President","Carter, Jimmy","democrat",FALSE,1636000,3150631,20171015,NA
+1976,"Florida","FL",12,59,43,"US President","Ford, Gerald","republican",FALSE,1469531,3150631,20171015,NA
+1976,"Florida","FL",12,59,43,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,23643,3150631,20171015,NA
+1976,"Florida","FL",12,59,43,"US President","Anderson, Thomas J.","american",FALSE,21325,3150631,20171015,NA
+1976,"Florida","FL",12,59,43,"US President","","",TRUE,132,3150631,20171015,NA
+1976,"Georgia","GA",13,58,44,"US President","Carter, Jimmy","democrat",FALSE,979409,1463152,20171015,NA
+1976,"Georgia","GA",13,58,44,"US President","Ford, Gerald","republican",FALSE,483743,1463152,20171015,NA
+1976,"Hawaii","HI",15,95,82,"US President","Carter, Jimmy","democrat",FALSE,147375,291301,20171015,NA
+1976,"Hawaii","HI",15,95,82,"US President","Ford, Gerald","republican",FALSE,140003,291301,20171015,NA
+1976,"Hawaii","HI",15,95,82,"US President","Macbride, Roger","libertarian",FALSE,3923,291301,20171015,NA
+1976,"Idaho","ID",16,82,63,"US President","Ford, Gerald","republican",FALSE,204151,340932,20171015,NA
+1976,"Idaho","ID",16,82,63,"US President","Carter, Jimmy","democrat",FALSE,126549,340932,20171015,NA
+1976,"Idaho","ID",16,82,63,"US President","Maddox, Lester","american",FALSE,5935,340932,20171015,NA
+1976,"Idaho","ID",16,82,63,"US President","Macbride, Roger","libertarian",FALSE,3558,340932,20171015,NA
+1976,"Idaho","ID",16,82,63,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,739,340932,20171015,NA
+1976,"Illinois","IL",17,33,21,"US President","Ford, Gerald","republican",FALSE,2364269,4721282,20171015,NA
+1976,"Illinois","IL",17,33,21,"US President","Carter, Jimmy","democrat",FALSE,2271295,4721282,20171015,NA
+1976,"Illinois","IL",17,33,21,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,55939,4721282,20171015,NA
+1976,"Illinois","IL",17,33,21,"US President","Hall, Gus","communist party use",FALSE,9250,4721282,20171015,NA
+1976,"Illinois","IL",17,33,21,"US President","Macbride, Roger","libertarian",FALSE,8057,4721282,20171015,NA
+1976,"Illinois","IL",17,33,21,"US President","","",TRUE,4417,4721282,20171015,NA
+1976,"Illinois","IL",17,33,21,"US President","Camejo, Peter","socialist workers",FALSE,3615,4721282,20171015,NA
+1976,"Illinois","IL",17,33,21,"US President","Julius """"Jules"""", Levin","socialist labor",FALSE,2422,4721282,20171015,NA
+1976,"Illinois","IL",17,33,21,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,2018,4721282,20171015,NA
+1976,"Indiana","IN",18,32,22,"US President","Ford, Gerald","republican",FALSE,1183958,2220362,20171015,NA
+1976,"Indiana","IN",18,32,22,"US President","Carter, Jimmy","democrat",FALSE,1014714,2220362,20171015,NA
+1976,"Indiana","IN",18,32,22,"US President","Anderson, Thomas J.","american",FALSE,14048,2220362,20171015,NA
+1976,"Indiana","IN",18,32,22,"US President","Camejo, Peter","socialist workers",FALSE,5695,2220362,20171015,NA
+1976,"Indiana","IN",18,32,22,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,1947,2220362,20171015,NA
+1976,"Iowa","IA",19,42,31,"US President","Ford, Gerald","republican",FALSE,632864,1279303,20171015,NA
+1976,"Iowa","IA",19,42,31,"US President","Carter, Jimmy","democrat",FALSE,619931,1279303,20171015,NA
+1976,"Iowa","IA",19,42,31,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,20057,1279303,20171015,NA
+1976,"Iowa","IA",19,42,31,"US President","Anderson, Thomas J.","american party of iowa",FALSE,3041,1279303,20171015,NA
+1976,"Iowa","IA",19,42,31,"US President","Macbride, Roger","libertarian",FALSE,1454,1279303,20171015,NA
+1976,"Iowa","IA",19,42,31,"US President","Hall, Gus","communist party use",FALSE,551,1279303,20171015,NA
+1976,"Iowa","IA",19,42,31,"US President","Scattering","",FALSE,509,1279303,20171015,NA
+1976,"Iowa","IA",19,42,31,"US President","Camejo, Peter","socialist workers",FALSE,262,1279303,20171015,NA
+1976,"Iowa","IA",19,42,31,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,241,1279303,20171015,NA
+1976,"Iowa","IA",19,42,31,"US President","Zeidler, Frank","socialist u.s.a.",FALSE,233,1279303,20171015,NA
+1976,"Iowa","IA",19,42,31,"US President","Julius """"Jules"""", Levin","socialist labor",FALSE,160,1279303,20171015,NA
+1976,"Kansas","KS",20,47,32,"US President","Ford, Gerald","republican",FALSE,502752,957845,20171015,NA
+1976,"Kansas","KS",20,47,32,"US President","Carter, Jimmy","democrat",FALSE,430421,957845,20171015,NA
+1976,"Kansas","KS",20,47,32,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,13185,957845,20171015,NA
+1976,"Kansas","KS",20,47,32,"US President","Anderson, Thomas J.","american",FALSE,4724,957845,20171015,NA
+1976,"Kansas","KS",20,47,32,"US President","Macbride, Roger","independent",FALSE,3242,957845,20171015,NA
+1976,"Kansas","KS",20,47,32,"US President","Maddox, Lester","conservative",FALSE,2118,957845,20171015,NA
+1976,"Kansas","KS",20,47,32,"US President","Bubar, Benjamin """"Ben""""","prohibition",FALSE,1403,957845,20171015,NA
+1976,"Kentucky","KY",21,61,51,"US President","Carter, Jimmy","democrat",FALSE,615717,1167142,20171015,NA
+1976,"Kentucky","KY",21,61,51,"US President","Ford, Gerald","republican",FALSE,531852,1167142,20171015,NA
+1976,"Kentucky","KY",21,61,51,"US President","Anderson, Thomas J.","american",FALSE,8308,1167142,20171015,NA
+1976,"Kentucky","KY",21,61,51,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,6837,1167142,20171015,NA
+1976,"Kentucky","KY",21,61,51,"US President","Maddox, Lester","american independent party",FALSE,2328,1167142,20171015,NA
+1976,"Kentucky","KY",21,61,51,"US President","Macbride, Roger","libertarian",FALSE,814,1167142,20171015,NA
+1976,"Kentucky","KY",21,61,51,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,510,1167142,20171015,NA
+1976,"Kentucky","KY",21,61,51,"US President","Hall, Gus","communist party use",FALSE,426,1167142,20171015,NA
+1976,"Kentucky","KY",21,61,51,"US President","Camejo, Peter","socialist workers",FALSE,350,1167142,20171015,NA
+1976,"Louisiana","LA",22,72,45,"US President","Carter, Jimmy","democrat",FALSE,661365,1277383,20171015,NA
+1976,"Louisiana","LA",22,72,45,"US President","Ford, Gerald","republican",FALSE,587446,1277383,20171015,NA
+1976,"Louisiana","LA",22,72,45,"US President","Maddox, Lester","american independent party",FALSE,10058,1277383,20171015,NA
+1976,"Louisiana","LA",22,72,45,"US President","Hall, Gus","communist party use",FALSE,7417,1277383,20171015,NA
+1976,"Louisiana","LA",22,72,45,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,6490,1277383,20171015,NA
+1976,"Louisiana","LA",22,72,45,"US President","Macbride, Roger","libertarian",FALSE,3134,1277383,20171015,NA
+1976,"Louisiana","LA",22,72,45,"US President","Camejo, Peter","socialist workers",FALSE,1473,1277383,20171015,NA
+1976,"Maine","ME",23,11,2,"US President","Ford, Gerald","republican",FALSE,236320,482968,20171015,NA
+1976,"Maine","ME",23,11,2,"US President","Carter, Jimmy","democrat",FALSE,232279,482968,20171015,NA
+1976,"Maine","ME",23,11,2,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,10874,482968,20171015,NA
+1976,"Maine","ME",23,11,2,"US President","Bubar, Benjamin """"Ben""""","prohibition",FALSE,3495,482968,20171015,NA
+1976,"Maryland","MD",24,52,52,"US President","Carter, Jimmy","democrat",FALSE,759612,1432273,20171015,NA
+1976,"Maryland","MD",24,52,52,"US President","Ford, Gerald","republican",FALSE,672661,1432273,20171015,NA
+1976,"Massachusetts","MA",25,14,3,"US President","Carter, Jimmy","democrat",FALSE,1429475,2547558,20171015,NA
+1976,"Massachusetts","MA",25,14,3,"US President","Ford, Gerald","republican",FALSE,1030276,2547558,20171015,NA
+1976,"Massachusetts","MA",25,14,3,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,65637,2547558,20171015,NA
+1976,"Massachusetts","MA",25,14,3,"US President","Camejo, Peter","socialist workers",FALSE,8138,2547558,20171015,NA
+1976,"Massachusetts","MA",25,14,3,"US President","Anderson, Thomas J.","american",FALSE,7555,2547558,20171015,NA
+1976,"Massachusetts","MA",25,14,3,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,4922,2547558,20171015,NA
+1976,"Massachusetts","MA",25,14,3,"US President","Scattering","",FALSE,1401,2547558,20171015,NA
+1976,"Massachusetts","MA",25,14,3,"US President","Macbride, Roger","libertarian",FALSE,135,2547558,20171015,NA
+1976,"Massachusetts","MA",25,14,3,"US President","Julius """"Jules"""", Levin","socialist labor",FALSE,19,2547558,20171015,NA
+1976,"Michigan","MI",26,34,23,"US President","Ford, Gerald","republican",FALSE,1893742,3651590,20171015,NA
+1976,"Michigan","MI",26,34,23,"US President","Carter, Jimmy","democrat",FALSE,1696714,3651590,20171015,NA
+1976,"Michigan","MI",26,34,23,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,47905,3651590,20171015,NA
+1976,"Michigan","MI",26,34,23,"US President","Macbride, Roger","libertarian",FALSE,5407,3651590,20171015,NA
+1976,"Michigan","MI",26,34,23,"US President","Wright, Margaret","human rights",FALSE,3504,3651590,20171015,NA
+1976,"Michigan","MI",26,34,23,"US President","Camejo, Peter","socialist workers",FALSE,1804,3651590,20171015,NA
+1976,"Michigan","MI",26,34,23,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,1366,3651590,20171015,NA
+1976,"Michigan","MI",26,34,23,"US President","Julius """"Jules"""", Levin","socialist labor",FALSE,1148,3651590,20171015,NA
+1976,"Minnesota","MN",27,41,33,"US President","Carter, Jimmy","democrat",FALSE,1070440,1949931,20171015,NA
+1976,"Minnesota","MN",27,41,33,"US President","Ford, Gerald","republican",FALSE,819395,1949931,20171015,NA
+1976,"Minnesota","MN",27,41,33,"US President","McCarthy, Eugene """"Gene""""","mccarthy '76",FALSE,35490,1949931,20171015,NA
+1976,"Minnesota","MN",27,41,33,"US President","Anderson, Thomas J.","american",FALSE,13592,1949931,20171015,NA
+1976,"Minnesota","MN",27,41,33,"US President","Camejo, Peter","socialist workers",FALSE,4149,1949931,20171015,NA
+1976,"Minnesota","MN",27,41,33,"US President","Macbride, Roger","libertarian",FALSE,3529,1949931,20171015,NA
+1976,"Minnesota","MN",27,41,33,"US President","Hall, Gus","communist party use",FALSE,1092,1949931,20171015,NA
+1976,"Minnesota","MN",27,41,33,"US President","Wright, Margaret","people's",FALSE,635,1949931,20171015,NA
+1976,"Minnesota","MN",27,41,33,"US President","Larouche, Lyndon, Jr.","international development bank",FALSE,543,1949931,20171015,NA
+1976,"Minnesota","MN",27,41,33,"US President","Julius """"Jules"""", Levin","industrial government party",FALSE,370,1949931,20171015,NA
+1976,"Minnesota","MN",27,41,33,"US President","Zeidler, Frank","socialist",FALSE,354,1949931,20171015,NA
+1976,"Minnesota","MN",27,41,33,"US President","","",TRUE,342,1949931,20171015,NA
+1976,"Mississippi","MS",28,64,46,"US President","Carter, Jimmy","democrat",FALSE,381329,768390,20171015,NA
+1976,"Mississippi","MS",28,64,46,"US President","Ford, Gerald","republican",FALSE,366846,768390,20171015,NA
+1976,"Mississippi","MS",28,64,46,"US President","Anderson, Thomas J.","american",FALSE,6678,768390,20171015,NA
+1976,"Mississippi","MS",28,64,46,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,4074,768390,20171015,NA
+1976,"Mississippi","MS",28,64,46,"US President","Maddox, Lester","american independent party",FALSE,4049,768390,20171015,NA
+1976,"Mississippi","MS",28,64,46,"US President","Camejo, Peter","socialist workers",FALSE,2805,768390,20171015,NA
+1976,"Mississippi","MS",28,64,46,"US President","Macbride, Roger","libertarian",FALSE,2609,768390,20171015,NA
+1976,"Missouri","MO",29,43,34,"US President","Carter, Jimmy","democrat",FALSE,998387,1953600,20171015,NA
+1976,"Missouri","MO",29,43,34,"US President","Ford, Gerald","republican",FALSE,927443,1953600,20171015,NA
+1976,"Missouri","MO",29,43,34,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,24029,1953600,20171015,NA
+1976,"Missouri","MO",29,43,34,"US President","Other","",FALSE,3741,1953600,20171015,NA
+1976,"Montana","MT",30,81,64,"US President","Ford, Gerald","republican",FALSE,173703,328734,20171015,NA
+1976,"Montana","MT",30,81,64,"US President","Carter, Jimmy","democrat",FALSE,149259,328734,20171015,NA
+1976,"Montana","MT",30,81,64,"US President","Anderson, Thomas J.","american",FALSE,5772,328734,20171015,NA
+1976,"Nebraska","NE",31,46,35,"US President","Ford, Gerald","republican",FALSE,359219,606749,20171015,NA
+1976,"Nebraska","NE",31,46,35,"US President","Carter, Jimmy","democrat",FALSE,233293,606749,20171015,NA
+1976,"Nebraska","NE",31,46,35,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,9383,606749,20171015,NA
+1976,"Nebraska","NE",31,46,35,"US President","Maddox, Lester","american independent party",FALSE,3378,606749,20171015,NA
+1976,"Nebraska","NE",31,46,35,"US President","Macbride, Roger","libertarian",FALSE,1476,606749,20171015,NA
+1976,"Nevada","NV",32,88,65,"US President","Ford, Gerald","republican",FALSE,101273,201876,20171015,NA
+1976,"Nevada","NV",32,88,65,"US President","Carter, Jimmy","democrat",FALSE,92479,201876,20171015,NA
+1976,"Nevada","NV",32,88,65,"US President","Other","",FALSE,5108,201876,20171015,NA
+1976,"Nevada","NV",32,88,65,"US President","Macbride, Roger","libertarian",FALSE,1519,201876,20171015,NA
+1976,"Nevada","NV",32,88,65,"US President","Maddox, Lester","american independent party",FALSE,1497,201876,20171015,NA
+1976,"New Hampshire","NH",33,12,4,"US President","Ford, Gerald","republican",FALSE,185935,339627,20171015,NA
+1976,"New Hampshire","NH",33,12,4,"US President","Carter, Jimmy","democrat",FALSE,147645,339627,20171015,NA
+1976,"New Hampshire","NH",33,12,4,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,4095,339627,20171015,NA
+1976,"New Hampshire","NH",33,12,4,"US President","Macbride, Roger","libertarian",FALSE,936,339627,20171015,NA
+1976,"New Hampshire","NH",33,12,4,"US President","Scattering","",FALSE,603,339627,20171015,NA
+1976,"New Hampshire","NH",33,12,4,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,186,339627,20171015,NA
+1976,"New Hampshire","NH",33,12,4,"US President","Camejo, Peter","socialist workers",FALSE,161,339627,20171015,NA
+1976,"New Hampshire","NH",33,12,4,"US President","Julius """"Jules"""", Levin","socialist labor",FALSE,66,339627,20171015,NA
+1976,"New Jersey","NJ",34,22,12,"US President","Ford, Gerald","republican",FALSE,1509688,3014472,20171015,NA
+1976,"New Jersey","NJ",34,22,12,"US President","Carter, Jimmy","democrat",FALSE,1444653,3014472,20171015,NA
+1976,"New Jersey","NJ",34,22,12,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,32717,3014472,20171015,NA
+1976,"New Jersey","NJ",34,22,12,"US President","Macbride, Roger","libertarian",FALSE,9449,3014472,20171015,NA
+1976,"New Jersey","NJ",34,22,12,"US President","Maddox, Lester","american independent party",FALSE,7716,3014472,20171015,NA
+1976,"New Jersey","NJ",34,22,12,"US President","Julius """"Jules"""", Levin","socialist labor",FALSE,3686,3014472,20171015,NA
+1976,"New Jersey","NJ",34,22,12,"US President","Hall, Gus","communist party use",FALSE,1662,3014472,20171015,NA
+1976,"New Jersey","NJ",34,22,12,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,1650,3014472,20171015,NA
+1976,"New Jersey","NJ",34,22,12,"US President","Camejo, Peter","socialist workers",FALSE,1184,3014472,20171015,NA
+1976,"New Jersey","NJ",34,22,12,"US President","Wright, Margaret","peace & freedom",FALSE,1044,3014472,20171015,NA
+1976,"New Jersey","NJ",34,22,12,"US President","Bubar, Benjamin """"Ben""""","prohibition",FALSE,554,3014472,20171015,NA
+1976,"New Jersey","NJ",34,22,12,"US President","Zeidler, Frank","socialist",FALSE,469,3014472,20171015,NA
+1976,"New Mexico","NM",35,85,66,"US President","Ford, Gerald","republican",FALSE,211419,416590,20171015,NA
+1976,"New Mexico","NM",35,85,66,"US President","Carter, Jimmy","democrat",FALSE,201148,416590,20171015,NA
+1976,"New Mexico","NM",35,85,66,"US President","Camejo, Peter","socialist workers",FALSE,2462,416590,20171015,NA
+1976,"New Mexico","NM",35,85,66,"US President","Macbride, Roger","libertarian",FALSE,1110,416590,20171015,NA
+1976,"New Mexico","NM",35,85,66,"US President","Zeidler, Frank","socialist",FALSE,240,416590,20171015,NA
+1976,"New Mexico","NM",35,85,66,"US President","Bubar, Benjamin """"Ben""""","prohibition",FALSE,211,416590,20171015,NA
+1976,"New York","NY",36,21,13,"US President","Carter, Jimmy","democrat",FALSE,3244165,6668262,20171015,NA
+1976,"New York","NY",36,21,13,"US President","Ford, Gerald","republican",FALSE,2825913,6668262,20171015,NA
+1976,"New York","NY",36,21,13,"US President","Ford, Gerald","conservative",FALSE,274878,6668262,20171015,NA
+1976,"New York","NY",36,21,13,"US President","Carter, Jimmy","liberal party",FALSE,145393,6668262,20171015,NA
+1976,"New York","NY",36,21,13,"US President","Other","",FALSE,143037,6668262,20171015,NA
+1976,"New York","NY",36,21,13,"US President","Macbride, Roger","free libertarian",FALSE,12197,6668262,20171015,NA
+1976,"New York","NY",36,21,13,"US President","Hall, Gus","communist party use",FALSE,10270,6668262,20171015,NA
+1976,"New York","NY",36,21,13,"US President","Camejo, Peter","socialist workers",FALSE,6996,6668262,20171015,NA
+1976,"New York","NY",36,21,13,"US President","Larouche, Lyndon, Jr.","labor",FALSE,5413,6668262,20171015,NA
+1976,"North Carolina","NC",37,56,47,"US President","Carter, Jimmy","democrat",FALSE,927365,1677906,20171015,NA
+1976,"North Carolina","NC",37,56,47,"US President","Ford, Gerald","republican",FALSE,741960,1677906,20171015,NA
+1976,"North Carolina","NC",37,56,47,"US President","Anderson, Thomas J.","american",FALSE,5607,1677906,20171015,NA
+1976,"North Carolina","NC",37,56,47,"US President","Macbride, Roger","libertarian",FALSE,2219,1677906,20171015,NA
+1976,"North Carolina","NC",37,56,47,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,755,1677906,20171015,NA
+1976,"North Dakota","ND",38,44,36,"US President","Ford, Gerald","republican",FALSE,153684,297308,20171015,NA
+1976,"North Dakota","ND",38,44,36,"US President","Carter, Jimmy","democrat",FALSE,136078,297308,20171015,NA
+1976,"North Dakota","ND",38,44,36,"US President","Anderson, Thomas J.","american",FALSE,3698,297308,20171015,NA
+1976,"North Dakota","ND",38,44,36,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,2952,297308,20171015,NA
+1976,"North Dakota","ND",38,44,36,"US President","Maddox, Lester","american independent party",FALSE,269,297308,20171015,NA
+1976,"North Dakota","ND",38,44,36,"US President","Macbride, Roger","libertarian",FALSE,256,297308,20171015,NA
+1976,"North Dakota","ND",38,44,36,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,142,297308,20171015,NA
+1976,"North Dakota","ND",38,44,36,"US President","Hall, Gus","communist party use",FALSE,85,297308,20171015,NA
+1976,"North Dakota","ND",38,44,36,"US President","Bubar, Benjamin """"Ben""""","prohibition",FALSE,63,297308,20171015,NA
+1976,"North Dakota","ND",38,44,36,"US President","Camejo, Peter","socialist workers",FALSE,43,297308,20171015,NA
+1976,"North Dakota","ND",38,44,36,"US President","Zeidler, Frank","socialist",FALSE,38,297308,20171015,NA
+1976,"Ohio","OH",39,31,24,"US President","Carter, Jimmy","democrat",FALSE,2009959,4110456,20171015,NA
+1976,"Ohio","OH",39,31,24,"US President","Ford, Gerald","republican",FALSE,2000626,4110456,20171015,NA
+1976,"Ohio","OH",39,31,24,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,58267,4110456,20171015,NA
+1976,"Ohio","OH",39,31,24,"US President","Maddox, Lester","american independent party",FALSE,15508,4110456,20171015,NA
+1976,"Ohio","OH",39,31,24,"US President","Macbride, Roger","libertarian",FALSE,8952,4110456,20171015,NA
+1976,"Ohio","OH",39,31,24,"US President","Hall, Gus","communist party use",FALSE,7817,4110456,20171015,NA
+1976,"Ohio","OH",39,31,24,"US President","Camejo, Peter","socialist workers",FALSE,4833,4110456,20171015,NA
+1976,"Ohio","OH",39,31,24,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,4364,4110456,20171015,NA
+1976,"Ohio","OH",39,31,24,"US President","Julius """"Jules"""", Levin","socialist labor",FALSE,68,4110456,20171015,NA
+1976,"Ohio","OH",39,31,24,"US President","Bubar, Benjamin """"Ben""""","prohibition",FALSE,62,4110456,20171015,NA
+1976,"Oklahoma","OK",40,73,53,"US President","Ford, Gerald","republican",FALSE,545708,1092251,20171015,NA
+1976,"Oklahoma","OK",40,73,53,"US President","Carter, Jimmy","democrat",FALSE,532442,1092251,20171015,NA
+1976,"Oklahoma","OK",40,73,53,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,14101,1092251,20171015,NA
+1976,"Oregon","OR",41,92,72,"US President","Ford, Gerald","republican",FALSE,492120,1029876,20171015,NA
+1976,"Oregon","OR",41,92,72,"US President","Carter, Jimmy","democrat",FALSE,490407,1029876,20171015,NA
+1976,"Oregon","OR",41,92,72,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,40207,1029876,20171015,NA
+1976,"Oregon","OR",41,92,72,"US President","","",TRUE,6107,1029876,20171015,NA
+1976,"Oregon","OR",41,92,72,"US President","Anderson, Thomas J.","american",FALSE,1035,1029876,20171015,NA
+1976,"Pennsylvania","PA",42,23,14,"US President","Carter, Jimmy","democrat",FALSE,2328677,4620787,20171015,NA
+1976,"Pennsylvania","PA",42,23,14,"US President","Ford, Gerald","republican",FALSE,2205604,4620787,20171015,NA
+1976,"Pennsylvania","PA",42,23,14,"US President","McCarthy, Eugene """"Gene""""","mccarthy '76",FALSE,50584,4620787,20171015,NA
+1976,"Pennsylvania","PA",42,23,14,"US President","Maddox, Lester","constitution party",FALSE,25344,4620787,20171015,NA
+1976,"Pennsylvania","PA",42,23,14,"US President","Camejo, Peter","socialist workers",FALSE,3009,4620787,20171015,NA
+1976,"Pennsylvania","PA",42,23,14,"US President","Other","",FALSE,2934,4620787,20171015,NA
+1976,"Pennsylvania","PA",42,23,14,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,2744,4620787,20171015,NA
+1976,"Pennsylvania","PA",42,23,14,"US President","Hall, Gus","communist party use",FALSE,1891,4620787,20171015,NA
+1976,"Rhode Island","RI",44,15,5,"US President","Carter, Jimmy","democrat",FALSE,227636,410584,20171015,NA
+1976,"Rhode Island","RI",44,15,5,"US President","Ford, Gerald","republican",FALSE,181249,410584,20171015,NA
+1976,"Rhode Island","RI",44,15,5,"US President","Macbride, Roger","libertarian",FALSE,715,410584,20171015,NA
+1976,"Rhode Island","RI",44,15,5,"US President","Camejo, Peter","socialist workers",FALSE,462,410584,20171015,NA
+1976,"Rhode Island","RI",44,15,5,"US President","Hall, Gus","communist party use",FALSE,334,410584,20171015,NA
+1976,"Rhode Island","RI",44,15,5,"US President","Julius """"Jules"""", Levin","socialist labor",FALSE,188,410584,20171015,NA
+1976,"South Carolina","SC",45,57,48,"US President","Carter, Jimmy","democrat",FALSE,450807,802583,20171015,NA
+1976,"South Carolina","SC",45,57,48,"US President","Ford, Gerald","republican",FALSE,346149,802583,20171015,NA
+1976,"South Carolina","SC",45,57,48,"US President","Anderson, Thomas J.","american",FALSE,2996,802583,20171015,NA
+1976,"South Carolina","SC",45,57,48,"US President","Maddox, Lester","american independent party",FALSE,1950,802583,20171015,NA
+1976,"South Carolina","SC",45,57,48,"US President","","",TRUE,681,802583,20171015,NA
+1976,"South Dakota","SD",46,45,37,"US President","Ford, Gerald","republican",FALSE,151505,300678,20171015,NA
+1976,"South Dakota","SD",46,45,37,"US President","Carter, Jimmy","democrat",FALSE,147068,300678,20171015,NA
+1976,"South Dakota","SD",46,45,37,"US President","Macbride, Roger","libertarian",FALSE,1619,300678,20171015,NA
+1976,"South Dakota","SD",46,45,37,"US President","Hall, Gus","communist party use",FALSE,318,300678,20171015,NA
+1976,"South Dakota","SD",46,45,37,"US President","Camejo, Peter","socialist workers",FALSE,168,300678,20171015,NA
+1976,"Tennessee","TN",47,62,54,"US President","Carter, Jimmy","democrat",FALSE,825879,1476346,20171015,NA
+1976,"Tennessee","TN",47,62,54,"US President","Ford, Gerald","republican",FALSE,633969,1476346,20171015,NA
+1976,"Tennessee","TN",47,62,54,"US President","Anderson, Thomas J.","independent",FALSE,5769,1476346,20171015,NA
+1976,"Tennessee","TN",47,62,54,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,5004,1476346,20171015,NA
+1976,"Tennessee","TN",47,62,54,"US President","Maddox, Lester","independent",FALSE,2303,1476346,20171015,NA
+1976,"Tennessee","TN",47,62,54,"US President","Macbride, Roger","independent",FALSE,1375,1476346,20171015,NA
+1976,"Tennessee","TN",47,62,54,"US President","Hall, Gus","independent",FALSE,547,1476346,20171015,NA
+1976,"Tennessee","TN",47,62,54,"US President","Larouche, Lyndon, Jr.","independent",FALSE,512,1476346,20171015,NA
+1976,"Tennessee","TN",47,62,54,"US President","Bubar, Benjamin """"Ben""""","independent",FALSE,442,1476346,20171015,NA
+1976,"Tennessee","TN",47,62,54,"US President","","independent",FALSE,316,1476346,20171015,NA
+1976,"Tennessee","TN",47,62,54,"US President","","",TRUE,230,1476346,20171015,NA
+1976,"Texas","TX",48,74,49,"US President","Carter, Jimmy","democrat",FALSE,2082319,4071884,20171015,NA
+1976,"Texas","TX",48,74,49,"US President","Ford, Gerald","republican",FALSE,1953300,4071884,20171015,NA
+1976,"Texas","TX",48,74,49,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,20118,4071884,20171015,NA
+1976,"Texas","TX",48,74,49,"US President","Anderson, Thomas J.","american",FALSE,11442,4071884,20171015,NA
+1976,"Texas","TX",48,74,49,"US President","","",TRUE,2982,4071884,20171015,NA
+1976,"Texas","TX",48,74,49,"US President","Camejo, Peter","socialist workers",FALSE,1723,4071884,20171015,NA
+1976,"Utah","UT",49,87,67,"US President","Ford, Gerald","republican",FALSE,337908,541218,20171015,NA
+1976,"Utah","UT",49,87,67,"US President","Carter, Jimmy","democrat",FALSE,182110,541218,20171015,NA
+1976,"Utah","UT",49,87,67,"US President","Anderson, Thomas J.","american",FALSE,13304,541218,20171015,NA
+1976,"Utah","UT",49,87,67,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,3907,541218,20171015,NA
+1976,"Utah","UT",49,87,67,"US President","Macbride, Roger","liberal party",FALSE,2438,541218,20171015,NA
+1976,"Utah","UT",49,87,67,"US President","Maddox, Lester","concerned citizens",FALSE,1162,541218,20171015,NA
+1976,"Utah","UT",49,87,67,"US President","Camejo, Peter","independent",FALSE,268,541218,20171015,NA
+1976,"Utah","UT",49,87,67,"US President","Hall, Gus","independent",FALSE,121,541218,20171015,NA
+1976,"Vermont","VT",50,13,6,"US President","Ford, Gerald","republican",FALSE,100387,183902,20171015,NA
+1976,"Vermont","VT",50,13,6,"US President","Carter, Jimmy","democrat",FALSE,77798,183902,20171015,NA
+1976,"Vermont","VT",50,13,6,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,4001,183902,20171015,NA
+1976,"Vermont","VT",50,13,6,"US President","Other","",FALSE,1090,183902,20171015,NA
+1976,"Vermont","VT",50,13,6,"US President","Camejo, Peter","socialist workers",FALSE,430,183902,20171015,NA
+1976,"Vermont","VT",50,13,6,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,196,183902,20171015,NA
+1976,"Virginia","VA",51,54,40,"US President","Ford, Gerald","republican",FALSE,836554,1697094,20171015,NA
+1976,"Virginia","VA",51,54,40,"US President","Carter, Jimmy","democrat",FALSE,813896,1697094,20171015,NA
+1976,"Virginia","VA",51,54,40,"US President","Camejo, Peter","socialist workers",FALSE,17802,1697094,20171015,NA
+1976,"Virginia","VA",51,54,40,"US President","Anderson, Thomas J.","american",FALSE,16686,1697094,20171015,NA
+1976,"Virginia","VA",51,54,40,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,7508,1697094,20171015,NA
+1976,"Virginia","VA",51,54,40,"US President","Macbride, Roger","libertarian",FALSE,4648,1697094,20171015,NA
+1976,"Washington","WA",53,91,73,"US President","Ford, Gerald","republican",FALSE,777732,1555534,20171015,NA
+1976,"Washington","WA",53,91,73,"US President","Carter, Jimmy","democrat",FALSE,717323,1555534,20171015,NA
+1976,"Washington","WA",53,91,73,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,36986,1555534,20171015,NA
+1976,"Washington","WA",53,91,73,"US President","Maddox, Lester","american independent party",FALSE,8585,1555534,20171015,NA
+1976,"Washington","WA",53,91,73,"US President","Other","",FALSE,5482,1555534,20171015,NA
+1976,"Washington","WA",53,91,73,"US President","Macbride, Roger","libertarian",FALSE,5042,1555534,20171015,NA
+1976,"Washington","WA",53,91,73,"US President","Anderson, Thomas J.","constitution party",FALSE,1046,1555534,20171015,NA
+1976,"Washington","WA",53,91,73,"US President","Camejo, Peter","socialist workers",FALSE,905,1555534,20171015,NA
+1976,"Washington","WA",53,91,73,"US President","Larouche, Lyndon, Jr.","u.s. labor",FALSE,903,1555534,20171015,NA
+1976,"Washington","WA",53,91,73,"US President","Hall, Gus","communist party use",FALSE,817,1555534,20171015,NA
+1976,"Washington","WA",53,91,73,"US President","Julius """"Jules"""", Levin","socialist labor",FALSE,713,1555534,20171015,NA
+1976,"West Virginia","WV",54,55,56,"US President","Carter, Jimmy","democrat",FALSE,435864,750590,20171015,NA
+1976,"West Virginia","WV",54,55,56,"US President","Ford, Gerald","republican",FALSE,314726,750590,20171015,NA
+1976,"Wisconsin","WI",55,35,25,"US President","Carter, Jimmy","democrat",FALSE,1040232,2101336,20171015,NA
+1976,"Wisconsin","WI",55,35,25,"US President","Ford, Gerald","republican",FALSE,1004987,2101336,20171015,NA
+1976,"Wisconsin","WI",55,35,25,"US President","McCarthy, Eugene """"Gene""""","independent",FALSE,34943,2101336,20171015,NA
+1976,"Wisconsin","WI",55,35,25,"US President","Maddox, Lester","american independent party",FALSE,8552,2101336,20171015,NA
+1976,"Wisconsin","WI",55,35,25,"US President","Zeidler, Frank","socialist",FALSE,4298,2101336,20171015,NA
+1976,"Wisconsin","WI",55,35,25,"US President","Macbride, Roger","libertarian",FALSE,3814,2101336,20171015,NA
+1976,"Wisconsin","WI",55,35,25,"US President","Other","",FALSE,2430,2101336,20171015,NA
+1976,"Wisconsin","WI",55,35,25,"US President","Camejo, Peter","socialist workers",FALSE,1691,2101336,20171015,NA
+1976,"Wisconsin","WI",55,35,25,"US President","Julius """"Jules"""", Levin","socialist labor",FALSE,389,2101336,20171015,NA
+1976,"Wyoming","WY",56,83,68,"US President","Ford, Gerald","republican",FALSE,92717,156343,20171015,NA
+1976,"Wyoming","WY",56,83,68,"US President","Carter, Jimmy","democrat",FALSE,62239,156343,20171015,NA
+1976,"Wyoming","WY",56,83,68,"US President","","",TRUE,1387,156343,20171015,NA
+1980,"Alabama","AL",1,63,41,"US President","Reagan, Ronald","republican",FALSE,654192,1341929,20171015,NA
+1980,"Alabama","AL",1,63,41,"US President","Carter, Jimmy","democrat",FALSE,636730,1341929,20171015,NA
+1980,"Alabama","AL",1,63,41,"US President","Anderson, John B.","independent",FALSE,16481,1341929,20171015,NA
+1980,"Alabama","AL",1,63,41,"US President","Rarick, John","conservative",FALSE,15010,1341929,20171015,NA
+1980,"Alabama","AL",1,63,41,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,13318,1341929,20171015,NA
+1980,"Alabama","AL",1,63,41,"US President","Bubar, Benjamin """"Ben""""","statesman",FALSE,1743,1341929,20171015,NA
+1980,"Alabama","AL",1,63,41,"US President","Hall, Gus","communist party use",FALSE,1629,1341929,20171015,NA
+1980,"Alabama","AL",1,63,41,"US President","Deberry, Clifton","socialist workers",FALSE,1303,1341929,20171015,NA
+1980,"Alabama","AL",1,63,41,"US President","McReynolds, David","socialist",FALSE,1006,1341929,20171015,NA
+1980,"Alabama","AL",1,63,41,"US President","Commoner, Barry","citizens",FALSE,517,1341929,20171015,NA
+1980,"Alaska","AK",2,94,81,"US President","Reagan, Ronald","republican",FALSE,86112,158445,20171015,NA
+1980,"Alaska","AK",2,94,81,"US President","Carter, Jimmy","democrat",FALSE,41842,158445,20171015,NA
+1980,"Alaska","AK",2,94,81,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,18479,158445,20171015,NA
+1980,"Alaska","AK",2,94,81,"US President","Anderson, John B.","independent",FALSE,11155,158445,20171015,NA
+1980,"Alaska","AK",2,94,81,"US President","","",TRUE,857,158445,20171015,NA
+1980,"Arizona","AZ",4,86,61,"US President","Reagan, Ronald","republican",FALSE,529688,873945,20171015,NA
+1980,"Arizona","AZ",4,86,61,"US President","Carter, Jimmy","democrat",FALSE,246843,873945,20171015,NA
+1980,"Arizona","AZ",4,86,61,"US President","Anderson, John B.","independent",FALSE,76952,873945,20171015,NA
+1980,"Arizona","AZ",4,86,61,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,18784,873945,20171015,NA
+1980,"Arizona","AZ",4,86,61,"US President","Deberry, Clifton","socialist workers",FALSE,1100,873945,20171015,NA
+1980,"Arizona","AZ",4,86,61,"US President","Commoner, Barry","citizens",FALSE,551,873945,20171015,NA
+1980,"Arizona","AZ",4,86,61,"US President","Hall, Gus","communist party use",FALSE,25,873945,20171015,NA
+1980,"Arizona","AZ",4,86,61,"US President","Griswold, Deirdre","workers world",FALSE,2,873945,20171015,NA
+1980,"Arkansas","AR",5,71,42,"US President","Reagan, Ronald","republican",FALSE,403164,837582,20171015,NA
+1980,"Arkansas","AR",5,71,42,"US President","Carter, Jimmy","democrat",FALSE,398041,837582,20171015,NA
+1980,"Arkansas","AR",5,71,42,"US President","Anderson, John B.","independent",FALSE,22468,837582,20171015,NA
+1980,"Arkansas","AR",5,71,42,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,8970,837582,20171015,NA
+1980,"Arkansas","AR",5,71,42,"US President","Commoner, Barry","citizens",FALSE,2345,837582,20171015,NA
+1980,"Arkansas","AR",5,71,42,"US President","Bubar, Benjamin """"Ben""""","statesman",FALSE,1350,837582,20171015,NA
+1980,"Arkansas","AR",5,71,42,"US President","Hall, Gus","communist party use",FALSE,1244,837582,20171015,NA
+1980,"California","CA",6,93,71,"US President","Reagan, Ronald","republican",FALSE,4522994,8582938,20171015,NA
+1980,"California","CA",6,93,71,"US President","Carter, Jimmy","democrat",FALSE,3082943,8582938,20171015,NA
+1980,"California","CA",6,93,71,"US President","Anderson, John B.","independent",FALSE,739618,8582938,20171015,NA
+1980,"California","CA",6,93,71,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,148390,8582938,20171015,NA
+1980,"California","CA",6,93,71,"US President","Commoner, Barry","citizens",FALSE,61046,8582938,20171015,NA
+1980,"California","CA",6,93,71,"US President","Smith, Maureen","peace & freedom",FALSE,18106,8582938,20171015,NA
+1980,"California","CA",6,93,71,"US President","Rarick, John","american independent party",FALSE,9841,8582938,20171015,NA
+1980,"Colorado","CO",8,84,62,"US President","Reagan, Ronald","republican",FALSE,652264,1184450,20171015,NA
+1980,"Colorado","CO",8,84,62,"US President","Carter, Jimmy","democrat",FALSE,368009,1184450,20171015,NA
+1980,"Colorado","CO",8,84,62,"US President","Anderson, John B.","national unity campaign",FALSE,130633,1184450,20171015,NA
+1980,"Colorado","CO",8,84,62,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,25744,1184450,20171015,NA
+1980,"Colorado","CO",8,84,62,"US President","Commoner, Barry","citizens",FALSE,5614,1184450,20171015,NA
+1980,"Colorado","CO",8,84,62,"US President","Bubar, Benjamin """"Ben""""","statesman",FALSE,1180,1184450,20171015,NA
+1980,"Colorado","CO",8,84,62,"US President","Pulley, Andrew","socialist workers",FALSE,519,1184450,20171015,NA
+1980,"Colorado","CO",8,84,62,"US President","Hall, Gus","communist party use",FALSE,487,1184450,20171015,NA
+1980,"Connecticut","CT",9,16,1,"US President","Reagan, Ronald","republican",FALSE,677210,1406285,20171015,NA
+1980,"Connecticut","CT",9,16,1,"US President","Carter, Jimmy","democrat",FALSE,541732,1406285,20171015,NA
+1980,"Connecticut","CT",9,16,1,"US President","Anderson, John B.","anderson coalition",FALSE,171807,1406285,20171015,NA
+1980,"Connecticut","CT",9,16,1,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,8570,1406285,20171015,NA
+1980,"Connecticut","CT",9,16,1,"US President","Commoner, Barry","citizens",FALSE,6130,1406285,20171015,NA
+1980,"Connecticut","CT",9,16,1,"US President","","",TRUE,836,1406285,20171015,NA
+1980,"Delaware","DE",10,51,11,"US President","Reagan, Ronald","republican",FALSE,111252,235668,20171015,NA
+1980,"Delaware","DE",10,51,11,"US President","Carter, Jimmy","democrat",FALSE,105754,235668,20171015,NA
+1980,"Delaware","DE",10,51,11,"US President","Anderson, John B.","independent",FALSE,16288,235668,20171015,NA
+1980,"Delaware","DE",10,51,11,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,1974,235668,20171015,NA
+1980,"Delaware","DE",10,51,11,"US President","Greaves, Percy L, Jr.","american",FALSE,400,235668,20171015,NA
+1980,"District of Columbia","DC",11,53,55,"US President","Carter, Jimmy","democrat",FALSE,130231,173889,20171015,NA
+1980,"District of Columbia","DC",11,53,55,"US President","Reagan, Ronald","republican",FALSE,23313,173889,20171015,NA
+1980,"District of Columbia","DC",11,53,55,"US President","Anderson, John B.","independent",FALSE,16131,173889,20171015,NA
+1980,"District of Columbia","DC",11,53,55,"US President","Commoner, Barry","citizens",FALSE,1826,173889,20171015,NA
+1980,"District of Columbia","DC",11,53,55,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,1104,173889,20171015,NA
+1980,"District of Columbia","DC",11,53,55,"US President","","",TRUE,690,173889,20171015,NA
+1980,"District of Columbia","DC",11,53,55,"US President","Hall, Gus","communist party use",FALSE,369,173889,20171015,NA
+1980,"District of Columbia","DC",11,53,55,"US President","Deberry, Clifton","socialist workers",FALSE,173,173889,20171015,NA
+1980,"District of Columbia","DC",11,53,55,"US President","Griswold, Deirdre","workers world",FALSE,52,173889,20171015,NA
+1980,"Florida","FL",12,59,43,"US President","Reagan, Ronald","republican",FALSE,2046951,3686927,20171015,NA
+1980,"Florida","FL",12,59,43,"US President","Carter, Jimmy","democrat",FALSE,1419475,3686927,20171015,NA
+1980,"Florida","FL",12,59,43,"US President","Anderson, John B.","independent",FALSE,189692,3686927,20171015,NA
+1980,"Florida","FL",12,59,43,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,30524,3686927,20171015,NA
+1980,"Florida","FL",12,59,43,"US President","","",TRUE,285,3686927,20171015,NA
+1980,"Georgia","GA",13,58,44,"US President","Carter, Jimmy","democrat",FALSE,890955,1596805,20171015,NA
+1980,"Georgia","GA",13,58,44,"US President","Reagan, Ronald","republican",FALSE,654168,1596805,20171015,NA
+1980,"Georgia","GA",13,58,44,"US President","Anderson, John B.","independent",FALSE,36055,1596805,20171015,NA
+1980,"Georgia","GA",13,58,44,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,15627,1596805,20171015,NA
+1980,"Hawaii","HI",15,95,82,"US President","Carter, Jimmy","democrat",FALSE,135879,303287,20171015,NA
+1980,"Hawaii","HI",15,95,82,"US President","Reagan, Ronald","republican",FALSE,130112,303287,20171015,NA
+1980,"Hawaii","HI",15,95,82,"US President","Anderson, John B.","independent",FALSE,32021,303287,20171015,NA
+1980,"Hawaii","HI",15,95,82,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,3269,303287,20171015,NA
+1980,"Hawaii","HI",15,95,82,"US President","Commoner, Barry","citizens",FALSE,1548,303287,20171015,NA
+1980,"Hawaii","HI",15,95,82,"US President","Hall, Gus","communist party use",FALSE,458,303287,20171015,NA
+1980,"Idaho","ID",16,82,63,"US President","Reagan, Ronald","republican",FALSE,290699,437431,20171015,NA
+1980,"Idaho","ID",16,82,63,"US President","Carter, Jimmy","democrat",FALSE,110192,437431,20171015,NA
+1980,"Idaho","ID",16,82,63,"US President","Anderson, John B.","independent",FALSE,27058,437431,20171015,NA
+1980,"Idaho","ID",16,82,63,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,8425,437431,20171015,NA
+1980,"Idaho","ID",16,82,63,"US President","Rarick, John","american independent party",FALSE,1057,437431,20171015,NA
+1980,"Illinois","IL",17,33,21,"US President","Reagan, Ronald","republican",FALSE,2358049,4749721,20171015,NA
+1980,"Illinois","IL",17,33,21,"US President","Carter, Jimmy","democrat",FALSE,1981413,4749721,20171015,NA
+1980,"Illinois","IL",17,33,21,"US President","Anderson, John B.","independent",FALSE,346754,4749721,20171015,NA
+1980,"Illinois","IL",17,33,21,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,38939,4749721,20171015,NA
+1980,"Illinois","IL",17,33,21,"US President","Commoner, Barry","citizens",FALSE,10692,4749721,20171015,NA
+1980,"Illinois","IL",17,33,21,"US President","Hall, Gus","communist party use",FALSE,9711,4749721,20171015,NA
+1980,"Illinois","IL",17,33,21,"US President","Griswold, Deirdre","workers world",FALSE,2257,4749721,20171015,NA
+1980,"Illinois","IL",17,33,21,"US President","Deberry, Clifton","socialist workers",FALSE,1302,4749721,20171015,NA
+1980,"Illinois","IL",17,33,21,"US President","","",TRUE,604,4749721,20171015,NA
+1980,"Indiana","IN",18,32,22,"US President","Reagan, Ronald","republican",FALSE,1255656,2242033,20171015,NA
+1980,"Indiana","IN",18,32,22,"US President","Carter, Jimmy","democrat",FALSE,844197,2242033,20171015,NA
+1980,"Indiana","IN",18,32,22,"US President","Anderson, John B.","independent",FALSE,111639,2242033,20171015,NA
+1980,"Indiana","IN",18,32,22,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,19627,2242033,20171015,NA
+1980,"Indiana","IN",18,32,22,"US President","Commoner, Barry","citizens",FALSE,4852,2242033,20171015,NA
+1980,"Indiana","IN",18,32,22,"US President","Greaves, Percy L, Jr.","american",FALSE,4750,2242033,20171015,NA
+1980,"Indiana","IN",18,32,22,"US President","Hall, Gus","communist party use",FALSE,702,2242033,20171015,NA
+1980,"Indiana","IN",18,32,22,"US President","Deberry, Clifton","socialist workers",FALSE,610,2242033,20171015,NA
+1980,"Iowa","IA",19,42,31,"US President","Reagan, Ronald","republican",FALSE,676026,1317661,20171015,NA
+1980,"Iowa","IA",19,42,31,"US President","Carter, Jimmy","democrat",FALSE,508672,1317661,20171015,NA
+1980,"Iowa","IA",19,42,31,"US President","Anderson, John B.","nominated by petition",FALSE,115633,1317661,20171015,NA
+1980,"Iowa","IA",19,42,31,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,13123,1317661,20171015,NA
+1980,"Iowa","IA",19,42,31,"US President","Commoner, Barry","citizens",FALSE,2273,1317661,20171015,NA
+1980,"Iowa","IA",19,42,31,"US President","McReynolds, David","socialist",FALSE,534,1317661,20171015,NA
+1980,"Iowa","IA",19,42,31,"US President","","",TRUE,519,1317661,20171015,NA
+1980,"Iowa","IA",19,42,31,"US President","Hall, Gus","communist party use",FALSE,298,1317661,20171015,NA
+1980,"Iowa","IA",19,42,31,"US President","Deberry, Clifton","socialist workers",FALSE,244,1317661,20171015,NA
+1980,"Iowa","IA",19,42,31,"US President","Greaves, Percy L, Jr.","american",FALSE,189,1317661,20171015,NA
+1980,"Iowa","IA",19,42,31,"US President","Bubar, Benjamin """"Ben""""","statesman",FALSE,150,1317661,20171015,NA
+1980,"Kansas","KS",20,47,32,"US President","Reagan, Ronald","republican",FALSE,566812,979795,20171015,NA
+1980,"Kansas","KS",20,47,32,"US President","Carter, Jimmy","democrat",FALSE,326150,979795,20171015,NA
+1980,"Kansas","KS",20,47,32,"US President","Anderson, John B.","independent",FALSE,68231,979795,20171015,NA
+1980,"Kansas","KS",20,47,32,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,14470,979795,20171015,NA
+1980,"Kansas","KS",20,47,32,"US President","Shelton, Frank, Jr.","american",FALSE,1555,979795,20171015,NA
+1980,"Kansas","KS",20,47,32,"US President","Hall, Gus","communist party use",FALSE,967,979795,20171015,NA
+1980,"Kansas","KS",20,47,32,"US President","Bubar, Benjamin """"Ben""""","statesman",FALSE,821,979795,20171015,NA
+1980,"Kansas","KS",20,47,32,"US President","Rarick, John","american independent party",FALSE,789,979795,20171015,NA
+1980,"Kentucky","KY",21,61,51,"US President","Reagan, Ronald","republican",FALSE,635274,1295627,20171015,NA
+1980,"Kentucky","KY",21,61,51,"US President","Carter, Jimmy","democrat",FALSE,617417,1295627,20171015,NA
+1980,"Kentucky","KY",21,61,51,"US President","Anderson, John B.","independent",FALSE,31127,1295627,20171015,NA
+1980,"Kentucky","KY",21,61,51,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,5531,1295627,20171015,NA
+1980,"Kentucky","KY",21,61,51,"US President","McCormack, Ellen","respect for life",FALSE,4233,1295627,20171015,NA
+1980,"Kentucky","KY",21,61,51,"US President","Commoner, Barry","citizens",FALSE,1304,1295627,20171015,NA
+1980,"Kentucky","KY",21,61,51,"US President","Pulley, Andrew","socialist workers",FALSE,393,1295627,20171015,NA
+1980,"Kentucky","KY",21,61,51,"US President","Hall, Gus","communist party use",FALSE,348,1295627,20171015,NA
+1980,"Louisiana","LA",22,72,45,"US President","Reagan, Ronald","republican",FALSE,792853,1548591,20171015,NA
+1980,"Louisiana","LA",22,72,45,"US President","Carter, Jimmy","democrat",FALSE,708453,1548591,20171015,NA
+1980,"Louisiana","LA",22,72,45,"US President","Anderson, John B.","independent",FALSE,26345,1548591,20171015,NA
+1980,"Louisiana","LA",22,72,45,"US President","Rarick, John","american independent party",FALSE,10333,1548591,20171015,NA
+1980,"Louisiana","LA",22,72,45,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,8240,1548591,20171015,NA
+1980,"Louisiana","LA",22,72,45,"US President","Commoner, Barry","citizens",FALSE,1584,1548591,20171015,NA
+1980,"Louisiana","LA",22,72,45,"US President","Deberry, Clifton","socialist workers",FALSE,783,1548591,20171015,NA
+1980,"Maine","ME",23,11,2,"US President","Reagan, Ronald","republican",FALSE,238522,523011,20171015,NA
+1980,"Maine","ME",23,11,2,"US President","Carter, Jimmy","democrat",FALSE,220974,523011,20171015,NA
+1980,"Maine","ME",23,11,2,"US President","Anderson, John B.","independent",FALSE,53327,523011,20171015,NA
+1980,"Maine","ME",23,11,2,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,5119,523011,20171015,NA
+1980,"Maine","ME",23,11,2,"US President","Commoner, Barry","citizens",FALSE,4394,523011,20171015,NA
+1980,"Maine","ME",23,11,2,"US President","Hall, Gus","communist party use",FALSE,591,523011,20171015,NA
+1980,"Maine","ME",23,11,2,"US President","","",TRUE,84,523011,20171015,NA
+1980,"Maryland","MD",24,52,52,"US President","Carter, Jimmy","democrat",FALSE,726161,1540496,20171015,NA
+1980,"Maryland","MD",24,52,52,"US President","Reagan, Ronald","republican",FALSE,680606,1540496,20171015,NA
+1980,"Maryland","MD",24,52,52,"US President","Anderson, John B.","independent",FALSE,119537,1540496,20171015,NA
+1980,"Maryland","MD",24,52,52,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,14192,1540496,20171015,NA
+1980,"Massachusetts","MA",25,14,3,"US President","Reagan, Ronald","republican",FALSE,1057631,2524090,20171015,NA
+1980,"Massachusetts","MA",25,14,3,"US President","Carter, Jimmy","democrat",FALSE,1053802,2524090,20171015,NA
+1980,"Massachusetts","MA",25,14,3,"US President","Anderson, John B.","independent",FALSE,382539,2524090,20171015,NA
+1980,"Massachusetts","MA",25,14,3,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,22038,2524090,20171015,NA
+1980,"Massachusetts","MA",25,14,3,"US President","Deberry, Clifton","socialist workers",FALSE,3735,2524090,20171015,NA
+1980,"Massachusetts","MA",25,14,3,"US President","","",TRUE,2289,2524090,20171015,NA
+1980,"Massachusetts","MA",25,14,3,"US President","Commoner, Barry","citizens",FALSE,2056,2524090,20171015,NA
+1980,"Michigan","MI",26,34,23,"US President","Reagan, Ronald","republican",FALSE,1915225,3909725,20171015,NA
+1980,"Michigan","MI",26,34,23,"US President","Carter, Jimmy","democrat",FALSE,1661532,3909725,20171015,NA
+1980,"Michigan","MI",26,34,23,"US President","Anderson, John B.","independent",FALSE,275223,3909725,20171015,NA
+1980,"Michigan","MI",26,34,23,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,41597,3909725,20171015,NA
+1980,"Michigan","MI",26,34,23,"US President","Commoner, Barry","citizens",FALSE,11930,3909725,20171015,NA
+1980,"Michigan","MI",26,34,23,"US President","Hall, Gus","communist party use",FALSE,3262,3909725,20171015,NA
+1980,"Michigan","MI",26,34,23,"US President","","",TRUE,956,3909725,20171015,NA
+1980,"Minnesota","MN",27,41,33,"US President","Carter, Jimmy","democrat",FALSE,954173,2051916,20171015,NA
+1980,"Minnesota","MN",27,41,33,"US President","Reagan, Ronald","republican",FALSE,873268,2051916,20171015,NA
+1980,"Minnesota","MN",27,41,33,"US President","Anderson, John B.","independent",FALSE,174997,2051916,20171015,NA
+1980,"Minnesota","MN",27,41,33,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,31593,2051916,20171015,NA
+1980,"Minnesota","MN",27,41,33,"US President","Commoner, Barry","citizens",FALSE,8406,2051916,20171015,NA
+1980,"Minnesota","MN",27,41,33,"US President","","american",FALSE,6136,2051916,20171015,NA
+1980,"Minnesota","MN",27,41,33,"US President","Hall, Gus","communist party use",FALSE,1117,2051916,20171015,NA
+1980,"Minnesota","MN",27,41,33,"US President","Deberry, Clifton","socialist workers",FALSE,711,2051916,20171015,NA
+1980,"Minnesota","MN",27,41,33,"US President","Griswold, Deirdre","workers world",FALSE,698,2051916,20171015,NA
+1980,"Minnesota","MN",27,41,33,"US President","McReynolds, David","socialist",FALSE,536,2051916,20171015,NA
+1980,"Minnesota","MN",27,41,33,"US President","","",TRUE,281,2051916,20171015,NA
+1980,"Mississippi","MS",28,64,46,"US President","Reagan, Ronald","republican",FALSE,441089,891750,20171015,NA
+1980,"Mississippi","MS",28,64,46,"US President","Carter, Jimmy","democrat",FALSE,429281,891750,20171015,NA
+1980,"Mississippi","MS",28,64,46,"US President","Anderson, John B.","independent",FALSE,12036,891750,20171015,NA
+1980,"Mississippi","MS",28,64,46,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,4702,891750,20171015,NA
+1980,"Mississippi","MS",28,64,46,"US President","Griswold, Deirdre","workers world",FALSE,2402,891750,20171015,NA
+1980,"Mississippi","MS",28,64,46,"US President","Pulley, Andrew","socialist workers",FALSE,2240,891750,20171015,NA
+1980,"Missouri","MO",29,43,34,"US President","Reagan, Ronald","republican",FALSE,1074181,2099824,20171015,NA
+1980,"Missouri","MO",29,43,34,"US President","Carter, Jimmy","democrat",FALSE,931182,2099824,20171015,NA
+1980,"Missouri","MO",29,43,34,"US President","Anderson, John B.","independent",FALSE,77920,2099824,20171015,NA
+1980,"Missouri","MO",29,43,34,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,14422,2099824,20171015,NA
+1980,"Missouri","MO",29,43,34,"US President","Deberry, Clifton","socialist workers",FALSE,1515,2099824,20171015,NA
+1980,"Missouri","MO",29,43,34,"US President","","",TRUE,604,2099824,20171015,NA
+1980,"Montana","MT",30,81,64,"US President","Reagan, Ronald","republican",FALSE,206814,363952,20171015,NA
+1980,"Montana","MT",30,81,64,"US President","Carter, Jimmy","democrat",FALSE,118032,363952,20171015,NA
+1980,"Montana","MT",30,81,64,"US President","Anderson, John B.","independent",FALSE,29281,363952,20171015,NA
+1980,"Montana","MT",30,81,64,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,9825,363952,20171015,NA
+1980,"Nebraska","NE",31,46,35,"US President","Reagan, Ronald","republican",FALSE,419214,639533,20171015,NA
+1980,"Nebraska","NE",31,46,35,"US President","Carter, Jimmy","democrat",FALSE,166424,639533,20171015,NA
+1980,"Nebraska","NE",31,46,35,"US President","Anderson, John B.","independent",FALSE,44854,639533,20171015,NA
+1980,"Nebraska","NE",31,46,35,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,9041,639533,20171015,NA
+1980,"Nevada","NV",32,88,65,"US President","Reagan, Ronald","republican",FALSE,155017,243692,20171015,NA
+1980,"Nevada","NV",32,88,65,"US President","Carter, Jimmy","democrat",FALSE,66666,243692,20171015,NA
+1980,"Nevada","NV",32,88,65,"US President","Anderson, John B.","independent",FALSE,17651,243692,20171015,NA
+1980,"Nevada","NV",32,88,65,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,4358,243692,20171015,NA
+1980,"New Hampshire","NH",33,12,4,"US President","Reagan, Ronald","republican",FALSE,221705,383990,20171015,NA
+1980,"New Hampshire","NH",33,12,4,"US President","Carter, Jimmy","democrat",FALSE,108864,383990,20171015,NA
+1980,"New Hampshire","NH",33,12,4,"US President","Anderson, John B.","independent",FALSE,49693,383990,20171015,NA
+1980,"New Hampshire","NH",33,12,4,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,2064,383990,20171015,NA
+1980,"New Hampshire","NH",33,12,4,"US President","Commoner, Barry","citizens",FALSE,1320,383990,20171015,NA
+1980,"New Hampshire","NH",33,12,4,"US President","Hall, Gus","communist party use",FALSE,129,383990,20171015,NA
+1980,"New Hampshire","NH",33,12,4,"US President","Griswold, Deirdre","workers world",FALSE,76,383990,20171015,NA
+1980,"New Hampshire","NH",33,12,4,"US President","Deberry, Clifton","socialist workers",FALSE,71,383990,20171015,NA
+1980,"New Hampshire","NH",33,12,4,"US President","","",TRUE,68,383990,20171015,NA
+1980,"New Jersey","NJ",34,22,12,"US President","Reagan, Ronald","republican",FALSE,1546557,2975684,20171015,NA
+1980,"New Jersey","NJ",34,22,12,"US President","Carter, Jimmy","democrat",FALSE,1147364,2975684,20171015,NA
+1980,"New Jersey","NJ",34,22,12,"US President","Anderson, John B.","independent",FALSE,234632,2975684,20171015,NA
+1980,"New Jersey","NJ",34,22,12,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,20652,2975684,20171015,NA
+1980,"New Jersey","NJ",34,22,12,"US President","Commoner, Barry","citizens",FALSE,8203,2975684,20171015,NA
+1980,"New Jersey","NJ",34,22,12,"US President","McCormack, Ellen","right-to-life",FALSE,3927,2975684,20171015,NA
+1980,"New Jersey","NJ",34,22,12,"US President","Lynen, Kurt","middle class candidate",FALSE,3694,2975684,20171015,NA
+1980,"New Jersey","NJ",34,22,12,"US President","Hall, Gus","communist party use",FALSE,2555,2975684,20171015,NA
+1980,"New Jersey","NJ",34,22,12,"US President","Pulley, Andrew","socialist workers",FALSE,2198,2975684,20171015,NA
+1980,"New Jersey","NJ",34,22,12,"US President","McReynolds, David","socialist",FALSE,1973,2975684,20171015,NA
+1980,"New Jersey","NJ",34,22,12,"US President","Gahres, William """"Bill""""","down with lawyers",FALSE,1718,2975684,20171015,NA
+1980,"New Jersey","NJ",34,22,12,"US President","Griswold, Deirdre","workers world",FALSE,1288,2975684,20171015,NA
+1980,"New Jersey","NJ",34,22,12,"US President","Wendelken, Martin E.","independent",FALSE,923,2975684,20171015,NA
+1980,"New Mexico","NM",35,85,66,"US President","Reagan, Ronald","republican",FALSE,250779,456237,20171015,NA
+1980,"New Mexico","NM",35,85,66,"US President","Carter, Jimmy","democrat",FALSE,167826,456237,20171015,NA
+1980,"New Mexico","NM",35,85,66,"US President","Anderson, John B.","independent",FALSE,29459,456237,20171015,NA
+1980,"New Mexico","NM",35,85,66,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,4365,456237,20171015,NA
+1980,"New Mexico","NM",35,85,66,"US President","Commoner, Barry","citizens",FALSE,2202,456237,20171015,NA
+1980,"New Mexico","NM",35,85,66,"US President","Bubar, Benjamin """"Ben""""","statesman",FALSE,1281,456237,20171015,NA
+1980,"New Mexico","NM",35,85,66,"US President","Pulley, Andrew","socialist workers",FALSE,325,456237,20171015,NA
+1980,"New York","NY",36,21,13,"US President","Carter, Jimmy","democrat",FALSE,2728372,6201959,20171015,NA
+1980,"New York","NY",36,21,13,"US President","Reagan, Ronald","republican",FALSE,2637700,6201959,20171015,NA
+1980,"New York","NY",36,21,13,"US President","Anderson, John B.","liberal party",FALSE,467801,6201959,20171015,NA
+1980,"New York","NY",36,21,13,"US President","Reagan, Ronald","conservative",FALSE,256131,6201959,20171015,NA
+1980,"New York","NY",36,21,13,"US President","Clark, Edward """"Ed""""","free libertarian",FALSE,52648,6201959,20171015,NA
+1980,"New York","NY",36,21,13,"US President","McCormack, Ellen","right-to-life",FALSE,24159,6201959,20171015,NA
+1980,"New York","NY",36,21,13,"US President","Commoner, Barry","citizens",FALSE,23186,6201959,20171015,NA
+1980,"New York","NY",36,21,13,"US President","Hall, Gus","communist party use",FALSE,7414,6201959,20171015,NA
+1980,"New York","NY",36,21,13,"US President","Deberry, Clifton","socialist workers",FALSE,2068,6201959,20171015,NA
+1980,"New York","NY",36,21,13,"US President","Griswold, Deirdre","workers world",FALSE,1416,6201959,20171015,NA
+1980,"New York","NY",36,21,13,"US President","","",TRUE,1064,6201959,20171015,NA
+1980,"North Carolina","NC",37,56,47,"US President","Reagan, Ronald","republican",FALSE,915018,1855833,20171015,NA
+1980,"North Carolina","NC",37,56,47,"US President","Carter, Jimmy","democrat",FALSE,875635,1855833,20171015,NA
+1980,"North Carolina","NC",37,56,47,"US President","Anderson, John B.","independent",FALSE,52800,1855833,20171015,NA
+1980,"North Carolina","NC",37,56,47,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,9677,1855833,20171015,NA
+1980,"North Carolina","NC",37,56,47,"US President","Commoner, Barry","citizens",FALSE,2287,1855833,20171015,NA
+1980,"North Carolina","NC",37,56,47,"US President","Deberry, Clifton","socialist workers",FALSE,416,1855833,20171015,NA
+1980,"North Dakota","ND",38,44,36,"US President","Reagan, Ronald","republican",FALSE,193695,301116,20171015,NA
+1980,"North Dakota","ND",38,44,36,"US President","Carter, Jimmy","democrat",FALSE,79189,301116,20171015,NA
+1980,"North Dakota","ND",38,44,36,"US President","Anderson, John B.","independent",FALSE,23640,301116,20171015,NA
+1980,"North Dakota","ND",38,44,36,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,3743,301116,20171015,NA
+1980,"North Dakota","ND",38,44,36,"US President","McLain, Harley","natural people's league",FALSE,296,301116,20171015,NA
+1980,"North Dakota","ND",38,44,36,"US President","Greaves, Percy L, Jr.","american",FALSE,235,301116,20171015,NA
+1980,"North Dakota","ND",38,44,36,"US President","Hall, Gus","communist party use",FALSE,93,301116,20171015,NA
+1980,"North Dakota","ND",38,44,36,"US President","Deberry, Clifton","socialist workers",FALSE,89,301116,20171015,NA
+1980,"North Dakota","ND",38,44,36,"US President","McReynolds, David","socialist",FALSE,82,301116,20171015,NA
+1980,"North Dakota","ND",38,44,36,"US President","Bubar, Benjamin """"Ben""""","statesman",FALSE,54,301116,20171015,NA
+1980,"Ohio","OH",39,31,24,"US President","Reagan, Ronald","republican",FALSE,2206545,4283603,20171015,NA
+1980,"Ohio","OH",39,31,24,"US President","Carter, Jimmy","democrat",FALSE,1752414,4283603,20171015,NA
+1980,"Ohio","OH",39,31,24,"US President","Anderson, John B.","independent",FALSE,254472,4283603,20171015,NA
+1980,"Ohio","OH",39,31,24,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,49033,4283603,20171015,NA
+1980,"Ohio","OH",39,31,24,"US President","Commoner, Barry","citizens",FALSE,8564,4283603,20171015,NA
+1980,"Ohio","OH",39,31,24,"US President","Hall, Gus","communist party use",FALSE,4729,4283603,20171015,NA
+1980,"Ohio","OH",39,31,24,"US President","Congress, Richard","socialist workers",FALSE,4029,4283603,20171015,NA
+1980,"Ohio","OH",39,31,24,"US President","Griswold, Deirdre","workers world",FALSE,3790,4283603,20171015,NA
+1980,"Ohio","OH",39,31,24,"US President","Bubar, Benjamin """"Ben""""","statesman",FALSE,27,4283603,20171015,NA
+1980,"Oklahoma","OK",40,73,53,"US President","Reagan, Ronald","republican",FALSE,695570,1149708,20171015,NA
+1980,"Oklahoma","OK",40,73,53,"US President","Carter, Jimmy","democrat",FALSE,402026,1149708,20171015,NA
+1980,"Oklahoma","OK",40,73,53,"US President","Anderson, John B.","independent",FALSE,38284,1149708,20171015,NA
+1980,"Oklahoma","OK",40,73,53,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,13828,1149708,20171015,NA
+1980,"Oregon","OR",41,92,72,"US President","Reagan, Ronald","republican",FALSE,571044,1181516,20171015,NA
+1980,"Oregon","OR",41,92,72,"US President","Carter, Jimmy","democrat",FALSE,456890,1181516,20171015,NA
+1980,"Oregon","OR",41,92,72,"US President","Anderson, John B.","independent",FALSE,112389,1181516,20171015,NA
+1980,"Oregon","OR",41,92,72,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,25838,1181516,20171015,NA
+1980,"Oregon","OR",41,92,72,"US President","Commoner, Barry","citizens",FALSE,13642,1181516,20171015,NA
+1980,"Oregon","OR",41,92,72,"US President","","",TRUE,1713,1181516,20171015,NA
+1980,"Pennsylvania","PA",42,23,14,"US President","Reagan, Ronald","republican",FALSE,2261872,4561501,20171015,NA
+1980,"Pennsylvania","PA",42,23,14,"US President","Carter, Jimmy","democrat",FALSE,1937540,4561501,20171015,NA
+1980,"Pennsylvania","PA",42,23,14,"US President","Anderson, John B.","independent",FALSE,292921,4561501,20171015,NA
+1980,"Pennsylvania","PA",42,23,14,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,33263,4561501,20171015,NA
+1980,"Pennsylvania","PA",42,23,14,"US President","Deberry, Clifton","socialist workers",FALSE,20291,4561501,20171015,NA
+1980,"Pennsylvania","PA",42,23,14,"US President","Commoner, Barry","citizens",FALSE,10430,4561501,20171015,NA
+1980,"Pennsylvania","PA",42,23,14,"US President","Hall, Gus","communist party use",FALSE,5184,4561501,20171015,NA
+1980,"Rhode Island","RI",44,15,5,"US President","Carter, Jimmy","democrat",FALSE,198342,415967,20171015,NA
+1980,"Rhode Island","RI",44,15,5,"US President","Reagan, Ronald","republican",FALSE,154793,415967,20171015,NA
+1980,"Rhode Island","RI",44,15,5,"US President","Anderson, John B.","independent",FALSE,59819,415967,20171015,NA
+1980,"Rhode Island","RI",44,15,5,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,2458,415967,20171015,NA
+1980,"Rhode Island","RI",44,15,5,"US President","Hall, Gus","communist party use",FALSE,218,415967,20171015,NA
+1980,"Rhode Island","RI",44,15,5,"US President","McReynolds, David","socialist",FALSE,170,415967,20171015,NA
+1980,"Rhode Island","RI",44,15,5,"US President","Deberry, Clifton","socialist workers",FALSE,90,415967,20171015,NA
+1980,"Rhode Island","RI",44,15,5,"US President","Griswold, Deirdre","workers world",FALSE,77,415967,20171015,NA
+1980,"South Carolina","SC",45,57,48,"US President","Reagan, Ronald","republican",FALSE,439277,888258,20171015,NA
+1980,"South Carolina","SC",45,57,48,"US President","Carter, Jimmy","democrat",FALSE,428220,888258,20171015,NA
+1980,"South Carolina","SC",45,57,48,"US President","Anderson, John B.","independent",FALSE,13868,888258,20171015,NA
+1980,"South Carolina","SC",45,57,48,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,4807,888258,20171015,NA
+1980,"South Carolina","SC",45,57,48,"US President","Rarick, John","american independent party",FALSE,2086,888258,20171015,NA
+1980,"South Dakota","SD",46,45,37,"US President","Reagan, Ronald","republican",FALSE,198343,327703,20171015,NA
+1980,"South Dakota","SD",46,45,37,"US President","Carter, Jimmy","democrat",FALSE,103855,327703,20171015,NA
+1980,"South Dakota","SD",46,45,37,"US President","Anderson, John B.","independent",FALSE,21431,327703,20171015,NA
+1980,"South Dakota","SD",46,45,37,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,3824,327703,20171015,NA
+1980,"South Dakota","SD",46,45,37,"US President","Pulley, Andrew","socialist workers",FALSE,250,327703,20171015,NA
+1980,"Tennessee","TN",47,62,54,"US President","Reagan, Ronald","republican",FALSE,787761,1617616,20171015,NA
+1980,"Tennessee","TN",47,62,54,"US President","Carter, Jimmy","democrat",FALSE,783051,1617616,20171015,NA
+1980,"Tennessee","TN",47,62,54,"US President","Anderson, John B.","independent",FALSE,35991,1617616,20171015,NA
+1980,"Tennessee","TN",47,62,54,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,7116,1617616,20171015,NA
+1980,"Tennessee","TN",47,62,54,"US President","Commoner, Barry","citizens",FALSE,1112,1617616,20171015,NA
+1980,"Tennessee","TN",47,62,54,"US President","Bubar, Benjamin """"Ben""""","statesman",FALSE,521,1617616,20171015,NA
+1980,"Tennessee","TN",47,62,54,"US President","McReynolds, David","socialist",FALSE,519,1617616,20171015,NA
+1980,"Tennessee","TN",47,62,54,"US President","Hall, Gus","communist party use",FALSE,503,1617616,20171015,NA
+1980,"Tennessee","TN",47,62,54,"US President","Deberry, Clifton","socialist workers",FALSE,490,1617616,20171015,NA
+1980,"Tennessee","TN",47,62,54,"US President","Griswold, Deirdre","workers world",FALSE,400,1617616,20171015,NA
+1980,"Tennessee","TN",47,62,54,"US President","","",TRUE,152,1617616,20171015,NA
+1980,"Texas","TX",48,74,49,"US President","Reagan, Ronald","republican",FALSE,2510705,4541636,20171015,NA
+1980,"Texas","TX",48,74,49,"US President","Carter, Jimmy","democrat",FALSE,1881147,4541636,20171015,NA
+1980,"Texas","TX",48,74,49,"US President","Anderson, John B.","independent",FALSE,111613,4541636,20171015,NA
+1980,"Texas","TX",48,74,49,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,37643,4541636,20171015,NA
+1980,"Texas","TX",48,74,49,"US President","","",TRUE,528,4541636,20171015,NA
+1980,"Utah","UT",49,87,67,"US President","Reagan, Ronald","republican",FALSE,439687,604152,20171015,NA
+1980,"Utah","UT",49,87,67,"US President","Carter, Jimmy","democrat",FALSE,124266,604152,20171015,NA
+1980,"Utah","UT",49,87,67,"US President","Anderson, John B.","independent",FALSE,30284,604152,20171015,NA
+1980,"Utah","UT",49,87,67,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,7156,604152,20171015,NA
+1980,"Utah","UT",49,87,67,"US President","Commoner, Barry","citizens",FALSE,1009,604152,20171015,NA
+1980,"Utah","UT",49,87,67,"US President","Greaves, Percy L, Jr.","american",FALSE,965,604152,20171015,NA
+1980,"Utah","UT",49,87,67,"US President","Rarick, John","american independent party",FALSE,522,604152,20171015,NA
+1980,"Utah","UT",49,87,67,"US President","Hall, Gus","communist party use",FALSE,139,604152,20171015,NA
+1980,"Utah","UT",49,87,67,"US President","Deberry, Clifton","socialist workers",FALSE,124,604152,20171015,NA
+1980,"Vermont","VT",50,13,6,"US President","Reagan, Ronald","republican",FALSE,94628,213299,20171015,NA
+1980,"Vermont","VT",50,13,6,"US President","Carter, Jimmy","democrat",FALSE,81952,213299,20171015,NA
+1980,"Vermont","VT",50,13,6,"US President","Anderson, John B.","independent",FALSE,31761,213299,20171015,NA
+1980,"Vermont","VT",50,13,6,"US President","Commoner, Barry","citizens",FALSE,2316,213299,20171015,NA
+1980,"Vermont","VT",50,13,6,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,1900,213299,20171015,NA
+1980,"Vermont","VT",50,13,6,"US President","","",TRUE,413,213299,20171015,NA
+1980,"Vermont","VT",50,13,6,"US President","McReynolds, David","socialist",FALSE,136,213299,20171015,NA
+1980,"Vermont","VT",50,13,6,"US President","Hall, Gus","communist party use",FALSE,118,213299,20171015,NA
+1980,"Vermont","VT",50,13,6,"US President","Deberry, Clifton","socialist workers",FALSE,75,213299,20171015,NA
+1980,"Virginia","VA",51,54,40,"US President","Reagan, Ronald","republican",FALSE,989609,1866032,20171015,NA
+1980,"Virginia","VA",51,54,40,"US President","Carter, Jimmy","democrat",FALSE,752174,1866032,20171015,NA
+1980,"Virginia","VA",51,54,40,"US President","Anderson, John B.","independent",FALSE,95418,1866032,20171015,NA
+1980,"Virginia","VA",51,54,40,"US President","Commoner, Barry","citizens",FALSE,14024,1866032,20171015,NA
+1980,"Virginia","VA",51,54,40,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,12821,1866032,20171015,NA
+1980,"Virginia","VA",51,54,40,"US President","Deberry, Clifton","socialist workers",FALSE,1986,1866032,20171015,NA
+1980,"Washington","WA",53,91,73,"US President","Reagan, Ronald","republican",FALSE,865244,1742394,20171015,NA
+1980,"Washington","WA",53,91,73,"US President","Carter, Jimmy","democrat",FALSE,650193,1742394,20171015,NA
+1980,"Washington","WA",53,91,73,"US President","Anderson, John B.","independent",FALSE,185073,1742394,20171015,NA
+1980,"Washington","WA",53,91,73,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,29213,1742394,20171015,NA
+1980,"Washington","WA",53,91,73,"US President","Commoner, Barry","citizens",FALSE,9403,1742394,20171015,NA
+1980,"Washington","WA",53,91,73,"US President","Deberry, Clifton","socialist workers",FALSE,1137,1742394,20171015,NA
+1980,"Washington","WA",53,91,73,"US President","McReynolds, David","socialist",FALSE,956,1742394,20171015,NA
+1980,"Washington","WA",53,91,73,"US President","Hall, Gus","communist party use",FALSE,834,1742394,20171015,NA
+1980,"Washington","WA",53,91,73,"US President","Griswold, Deirdre","workers world",FALSE,341,1742394,20171015,NA
+1980,"West Virginia","WV",54,55,56,"US President","Carter, Jimmy","democrat",FALSE,367462,737715,20171015,NA
+1980,"West Virginia","WV",54,55,56,"US President","Reagan, Ronald","republican",FALSE,334206,737715,20171015,NA
+1980,"West Virginia","WV",54,55,56,"US President","Anderson, John B.","independent",FALSE,31691,737715,20171015,NA
+1980,"West Virginia","WV",54,55,56,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,4356,737715,20171015,NA
+1980,"Wisconsin","WI",55,35,25,"US President","Reagan, Ronald","republican",FALSE,1088845,2273221,20171015,NA
+1980,"Wisconsin","WI",55,35,25,"US President","Carter, Jimmy","democrat",FALSE,981584,2273221,20171015,NA
+1980,"Wisconsin","WI",55,35,25,"US President","Anderson, John B.","independent",FALSE,160657,2273221,20171015,NA
+1980,"Wisconsin","WI",55,35,25,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,29135,2273221,20171015,NA
+1980,"Wisconsin","WI",55,35,25,"US President","Commoner, Barry","citizens",FALSE,7767,2273221,20171015,NA
+1980,"Wisconsin","WI",55,35,25,"US President","Rarick, John","american independent party",FALSE,1519,2273221,20171015,NA
+1980,"Wisconsin","WI",55,35,25,"US President","","",TRUE,1337,2273221,20171015,NA
+1980,"Wisconsin","WI",55,35,25,"US President","McReynolds, David","socialist",FALSE,808,2273221,20171015,NA
+1980,"Wisconsin","WI",55,35,25,"US President","Hall, Gus","communist party use",FALSE,772,2273221,20171015,NA
+1980,"Wisconsin","WI",55,35,25,"US President","Griswold, Deirdre","workers world",FALSE,414,2273221,20171015,NA
+1980,"Wisconsin","WI",55,35,25,"US President","Deberry, Clifton","socialist workers",FALSE,383,2273221,20171015,NA
+1980,"Wyoming","WY",56,83,68,"US President","Reagan, Ronald","republican",FALSE,110700,176713,20171015,NA
+1980,"Wyoming","WY",56,83,68,"US President","Carter, Jimmy","democrat",FALSE,49427,176713,20171015,NA
+1980,"Wyoming","WY",56,83,68,"US President","Anderson, John B.","independent",FALSE,12072,176713,20171015,NA
+1980,"Wyoming","WY",56,83,68,"US President","Clark, Edward """"Ed""""","libertarian",FALSE,4514,176713,20171015,NA
+1984,"Alabama","AL",1,63,41,"US President","Reagan, Ronald","republican",FALSE,872849,1441713,20171015,NA
+1984,"Alabama","AL",1,63,41,"US President","Mondale, Walter","democrat",FALSE,551899,1441713,20171015,NA
+1984,"Alabama","AL",1,63,41,"US President","Bergland, David","libertarian",FALSE,9504,1441713,20171015,NA
+1984,"Alabama","AL",1,63,41,"US President","Hall, Gus","communist party use",FALSE,4671,1441713,20171015,NA
+1984,"Alabama","AL",1,63,41,"US President","Richards, Bob","populist",FALSE,1401,1441713,20171015,NA
+1984,"Alabama","AL",1,63,41,"US President","Mason, Melvin","socialist workers",FALSE,730,1441713,20171015,NA
+1984,"Alabama","AL",1,63,41,"US President","Serrette, Dennis","alliance",FALSE,659,1441713,20171015,NA
+1984,"Alaska","AK",2,94,81,"US President","Reagan, Ronald","republican",FALSE,138377,207605,20171015,NA
+1984,"Alaska","AK",2,94,81,"US President","Mondale, Walter","democrat",FALSE,62007,207605,20171015,NA
+1984,"Alaska","AK",2,94,81,"US President","Bergland, David","libertarian",FALSE,6378,207605,20171015,NA
+1984,"Alaska","AK",2,94,81,"US President","Other","",FALSE,843,207605,20171015,NA
+1984,"Arizona","AZ",4,86,61,"US President","Reagan, Ronald","republican",FALSE,681416,1025897,20171015,NA
+1984,"Arizona","AZ",4,86,61,"US President","Mondale, Walter","democrat",FALSE,333854,1025897,20171015,NA
+1984,"Arizona","AZ",4,86,61,"US President","Bergland, David","libertarian",FALSE,10585,1025897,20171015,NA
+1984,"Arizona","AZ",4,86,61,"US President","Other","",FALSE,42,1025897,20171015,NA
+1984,"Arkansas","AR",5,71,42,"US President","Reagan, Ronald","republican",FALSE,534774,884406,20171015,NA
+1984,"Arkansas","AR",5,71,42,"US President","Mondale, Walter","democrat",FALSE,338646,884406,20171015,NA
+1984,"Arkansas","AR",5,71,42,"US President","Bergland, David","libertarian",FALSE,2221,884406,20171015,NA
+1984,"Arkansas","AR",5,71,42,"US President","Larouche, Lyndon, Jr.","independent",FALSE,1890,884406,20171015,NA
+1984,"Arkansas","AR",5,71,42,"US President","Hall, Gus","communist party use",FALSE,1499,884406,20171015,NA
+1984,"Arkansas","AR",5,71,42,"US President","Richards, Bob","populist",FALSE,1461,884406,20171015,NA
+1984,"Arkansas","AR",5,71,42,"US President","Serrette, Dennis","alliance",FALSE,1291,884406,20171015,NA
+1984,"Arkansas","AR",5,71,42,"US President","Johnson, Sonia","citizens",FALSE,960,884406,20171015,NA
+1984,"Arkansas","AR",5,71,42,"US President","Dodge, Earl","prohibition",FALSE,842,884406,20171015,NA
+1984,"Arkansas","AR",5,71,42,"US President","Lowery, Arthur","united sovereign citizens",FALSE,822,884406,20171015,NA
+1984,"California","CA",6,93,71,"US President","Reagan, Ronald","republican",FALSE,5467009,9505041,20171015,NA
+1984,"California","CA",6,93,71,"US President","Mondale, Walter","democrat",FALSE,3922519,9505041,20171015,NA
+1984,"California","CA",6,93,71,"US President","Bergland, David","libertarian",FALSE,49951,9505041,20171015,NA
+1984,"California","CA",6,93,71,"US President","Richards, Bob","populist",FALSE,39265,9505041,20171015,NA
+1984,"California","CA",6,93,71,"US President","Johnson, Sonia","citizens",FALSE,26297,9505041,20171015,NA
+1984,"Colorado","CO",8,84,62,"US President","Reagan, Ronald","republican",FALSE,821817,1295380,20171015,NA
+1984,"Colorado","CO",8,84,62,"US President","Mondale, Walter","democrat",FALSE,454975,1295380,20171015,NA
+1984,"Colorado","CO",8,84,62,"US President","Bergland, David","libertarian",FALSE,11257,1295380,20171015,NA
+1984,"Colorado","CO",8,84,62,"US President","Larouche, Lyndon, Jr.","independent",FALSE,4662,1295380,20171015,NA
+1984,"Colorado","CO",8,84,62,"US President","Serrette, Dennis","alliance",FALSE,978,1295380,20171015,NA
+1984,"Colorado","CO",8,84,62,"US President","Dodge, Earl","prohibition",FALSE,858,1295380,20171015,NA
+1984,"Colorado","CO",8,84,62,"US President","Mason, Melvin","socialist workers",FALSE,810,1295380,20171015,NA
+1984,"Colorado","CO",8,84,62,"US President","Other","",FALSE,23,1295380,20171015,NA
+1984,"Connecticut","CT",9,16,1,"US President","Reagan, Ronald","republican",FALSE,890877,1466900,20171015,NA
+1984,"Connecticut","CT",9,16,1,"US President","Mondale, Walter","democrat",FALSE,569597,1466900,20171015,NA
+1984,"Connecticut","CT",9,16,1,"US President","Hall, Gus","communist party use",FALSE,4826,1466900,20171015,NA
+1984,"Connecticut","CT",9,16,1,"US President","Serrette, Dennis","alliance",FALSE,1374,1466900,20171015,NA
+1984,"Connecticut","CT",9,16,1,"US President","Other","",FALSE,226,1466900,20171015,NA
+1984,"Delaware","DE",10,51,11,"US President","Reagan, Ronald","republican",FALSE,152190,254572,20171015,NA
+1984,"Delaware","DE",10,51,11,"US President","Mondale, Walter","democrat",FALSE,101656,254572,20171015,NA
+1984,"Delaware","DE",10,51,11,"US President","Dennis, Delmar","american",FALSE,269,254572,20171015,NA
+1984,"Delaware","DE",10,51,11,"US President","Bergland, David","libertarian",FALSE,268,254572,20171015,NA
+1984,"Delaware","DE",10,51,11,"US President","Johnson, Sonia","citizens",FALSE,121,254572,20171015,NA
+1984,"Delaware","DE",10,51,11,"US President","Serrette, Dennis","alliance",FALSE,68,254572,20171015,NA
+1984,"District of Columbia","DC",11,53,55,"US President","Mondale, Walter","democrat",FALSE,180408,211288,20171015,NA
+1984,"District of Columbia","DC",11,53,55,"US President","Reagan, Ronald","republican",FALSE,29009,211288,20171015,NA
+1984,"District of Columbia","DC",11,53,55,"US President","Other","",FALSE,809,211288,20171015,NA
+1984,"District of Columbia","DC",11,53,55,"US President","Bergland, David","libertarian",FALSE,279,211288,20171015,NA
+1984,"District of Columbia","DC",11,53,55,"US President","Hall, Gus","communist party use",FALSE,257,211288,20171015,NA
+1984,"District of Columbia","DC",11,53,55,"US President","Serrette, Dennis","alliance",FALSE,165,211288,20171015,NA
+1984,"District of Columbia","DC",11,53,55,"US President","Larouche, Lyndon, Jr.","independent",FALSE,127,211288,20171015,NA
+1984,"District of Columbia","DC",11,53,55,"US President","Mason, Melvin","socialist workers",FALSE,127,211288,20171015,NA
+1984,"District of Columbia","DC",11,53,55,"US President","Holmes, Larry","workers world",FALSE,107,211288,20171015,NA
+1984,"Florida","FL",12,59,43,"US President","Reagan, Ronald","republican",FALSE,2730350,4180051,20171015,NA
+1984,"Florida","FL",12,59,43,"US President","Mondale, Walter","democrat",FALSE,1448816,4180051,20171015,NA
+1984,"Florida","FL",12,59,43,"US President","Other","",FALSE,885,4180051,20171015,NA
+1984,"Georgia","GA",13,58,44,"US President","Reagan, Ronald","republican",FALSE,1068722,1776103,20171015,NA
+1984,"Georgia","GA",13,58,44,"US President","Mondale, Walter","democrat",FALSE,706628,1776103,20171015,NA
+1984,"Georgia","GA",13,58,44,"US President","Other","",FALSE,753,1776103,20171015,NA
+1984,"Hawaii","HI",15,95,82,"US President","Reagan, Ronald","republican",FALSE,185050,335846,20171015,NA
+1984,"Hawaii","HI",15,95,82,"US President","Mondale, Walter","democrat",FALSE,147154,335846,20171015,NA
+1984,"Hawaii","HI",15,95,82,"US President","Bergland, David","libertarian",FALSE,2167,335846,20171015,NA
+1984,"Hawaii","HI",15,95,82,"US President","Hall, Gus","communist party use",FALSE,821,335846,20171015,NA
+1984,"Hawaii","HI",15,95,82,"US President","Larouche, Lyndon, Jr.","independent",FALSE,654,335846,20171015,NA
+1984,"Idaho","ID",16,82,63,"US President","Reagan, Ronald","republican",FALSE,297523,411144,20171015,NA
+1984,"Idaho","ID",16,82,63,"US President","Mondale, Walter","democrat",FALSE,108510,411144,20171015,NA
+1984,"Idaho","ID",16,82,63,"US President","Bergland, David","libertarian",FALSE,2823,411144,20171015,NA
+1984,"Idaho","ID",16,82,63,"US President","Richards, Bob","populist",FALSE,2288,411144,20171015,NA
+1984,"Illinois","IL",17,33,21,"US President","Reagan, Ronald","republican",FALSE,2707103,4819088,20171015,NA
+1984,"Illinois","IL",17,33,21,"US President","Mondale, Walter","democrat",FALSE,2086499,4819088,20171015,NA
+1984,"Illinois","IL",17,33,21,"US President","Bergland, David","libertarian",FALSE,10086,4819088,20171015,NA
+1984,"Illinois","IL",17,33,21,"US President","Hall, Gus","communist party use",FALSE,4672,4819088,20171015,NA
+1984,"Illinois","IL",17,33,21,"US President","Johnson, Sonia","citizens",FALSE,2716,4819088,20171015,NA
+1984,"Illinois","IL",17,33,21,"US President","Winn, Edward","workers league",FALSE,2632,4819088,20171015,NA
+1984,"Illinois","IL",17,33,21,"US President","Serrette, Dennis","alliance",FALSE,2386,4819088,20171015,NA
+1984,"Illinois","IL",17,33,21,"US President","Mason, Melvin","socialist workers",FALSE,2132,4819088,20171015,NA
+1984,"Illinois","IL",17,33,21,"US President","Other","",FALSE,862,4819088,20171015,NA
+1984,"Indiana","IN",18,32,22,"US President","Reagan, Ronald","republican",FALSE,1377230,2233069,20171015,NA
+1984,"Indiana","IN",18,32,22,"US President","Mondale, Walter","democrat",FALSE,841481,2233069,20171015,NA
+1984,"Indiana","IN",18,32,22,"US President","Dennis, Delmar","american",FALSE,7617,2233069,20171015,NA
+1984,"Indiana","IN",18,32,22,"US President","Bergland, David","libertarian",FALSE,6741,2233069,20171015,NA
+1984,"Iowa","IA",19,42,31,"US President","Reagan, Ronald","republican",FALSE,703088,1319805,20171015,NA
+1984,"Iowa","IA",19,42,31,"US President","Mondale, Walter","democrat",FALSE,605620,1319805,20171015,NA
+1984,"Iowa","IA",19,42,31,"US President","Larouche, Lyndon, Jr.","independent",FALSE,6248,1319805,20171015,NA
+1984,"Iowa","IA",19,42,31,"US President","Bergland, David","libertarian",FALSE,1844,1319805,20171015,NA
+1984,"Iowa","IA",19,42,31,"US President","Other","",FALSE,1051,1319805,20171015,NA
+1984,"Iowa","IA",19,42,31,"US President","Baker, Gerald","big deal party",FALSE,892,1319805,20171015,NA
+1984,"Iowa","IA",19,42,31,"US President","Serrette, Dennis","alliance",FALSE,463,1319805,20171015,NA
+1984,"Iowa","IA",19,42,31,"US President","Mason, Melvin","socialist workers",FALSE,313,1319805,20171015,NA
+1984,"Iowa","IA",19,42,31,"US President","Hall, Gus","communist party use",FALSE,286,1319805,20171015,NA
+1984,"Kansas","KS",20,47,32,"US President","Reagan, Ronald","republican",FALSE,677296,1021991,20171015,NA
+1984,"Kansas","KS",20,47,32,"US President","Mondale, Walter","democrat",FALSE,333149,1021991,20171015,NA
+1984,"Kansas","KS",20,47,32,"US President","Richards, Bob","populist",FALSE,3564,1021991,20171015,NA
+1984,"Kansas","KS",20,47,32,"US President","Bergland, David","libertarian",FALSE,3329,1021991,20171015,NA
+1984,"Kansas","KS",20,47,32,"US President","Serrette, Dennis","alliance",FALSE,2544,1021991,20171015,NA
+1984,"Kansas","KS",20,47,32,"US President","Dodge, Earl","prohibition",FALSE,2109,1021991,20171015,NA
+1984,"Kentucky","KY",21,61,51,"US President","Reagan, Ronald","republican",FALSE,821702,1369345,20171015,NA
+1984,"Kentucky","KY",21,61,51,"US President","Mondale, Walter","democrat",FALSE,539539,1369345,20171015,NA
+1984,"Kentucky","KY",21,61,51,"US President","Mason, Melvin","socialist workers",FALSE,3129,1369345,20171015,NA
+1984,"Kentucky","KY",21,61,51,"US President","Larouche, Lyndon, Jr.","independent",FALSE,1776,1369345,20171015,NA
+1984,"Kentucky","KY",21,61,51,"US President","Anderson, John B.","national unity",FALSE,1479,1369345,20171015,NA
+1984,"Kentucky","KY",21,61,51,"US President","Johnson, Sonia","citizens",FALSE,599,1369345,20171015,NA
+1984,"Kentucky","KY",21,61,51,"US President","Dennis, Delmar","american",FALSE,428,1369345,20171015,NA
+1984,"Kentucky","KY",21,61,51,"US President","Serrette, Dennis","alliance",FALSE,365,1369345,20171015,NA
+1984,"Kentucky","KY",21,61,51,"US President","Hall, Gus","communist party use",FALSE,328,1369345,20171015,NA
+1984,"Louisiana","LA",22,72,45,"US President","Reagan, Ronald","republican",FALSE,1037299,1706822,20171015,NA
+1984,"Louisiana","LA",22,72,45,"US President","Mondale, Walter","democrat",FALSE,651586,1706822,20171015,NA
+1984,"Louisiana","LA",22,72,45,"US President","Johnson, Sonia","citizens",FALSE,9502,1706822,20171015,NA
+1984,"Louisiana","LA",22,72,45,"US President","Larouche, Lyndon, Jr.","independent",FALSE,3552,1706822,20171015,NA
+1984,"Louisiana","LA",22,72,45,"US President","Bergland, David","libertarian",FALSE,1876,1706822,20171015,NA
+1984,"Louisiana","LA",22,72,45,"US President","Richards, Bob","populist",FALSE,1310,1706822,20171015,NA
+1984,"Louisiana","LA",22,72,45,"US President","Mason, Melvin","socialist workers",FALSE,1164,1706822,20171015,NA
+1984,"Louisiana","LA",22,72,45,"US President","Serrette, Dennis","alliance",FALSE,533,1706822,20171015,NA
+1984,"Maine","ME",23,11,2,"US President","Reagan, Ronald","republican",FALSE,336500,553144,20171015,NA
+1984,"Maine","ME",23,11,2,"US President","Mondale, Walter","democrat",FALSE,214515,553144,20171015,NA
+1984,"Maine","ME",23,11,2,"US President","Hall, Gus","communist party use",FALSE,1292,553144,20171015,NA
+1984,"Maine","ME",23,11,2,"US President","Serrette, Dennis","alliance",FALSE,755,553144,20171015,NA
+1984,"Maine","ME",23,11,2,"US President","Other","",FALSE,82,553144,20171015,NA
+1984,"Maryland","MD",24,52,52,"US President","Reagan, Ronald","republican",FALSE,879918,1675873,20171015,NA
+1984,"Maryland","MD",24,52,52,"US President","Mondale, Walter","democrat",FALSE,787935,1675873,20171015,NA
+1984,"Maryland","MD",24,52,52,"US President","Bergland, David","libertarian",FALSE,5721,1675873,20171015,NA
+1984,"Maryland","MD",24,52,52,"US President","Hall, Gus","communist party use",FALSE,898,1675873,20171015,NA
+1984,"Maryland","MD",24,52,52,"US President","Holmes, Larry","workers world",FALSE,745,1675873,20171015,NA
+1984,"Maryland","MD",24,52,52,"US President","Serrette, Dennis","alliance",FALSE,656,1675873,20171015,NA
+1984,"Massachusetts","MA",25,14,3,"US President","Reagan, Ronald","republican",FALSE,1310936,2559383,20171015,NA
+1984,"Massachusetts","MA",25,14,3,"US President","Mondale, Walter","democrat",FALSE,1239606,2559383,20171015,NA
+1984,"Massachusetts","MA",25,14,3,"US President","Serrette, Dennis","alliance",FALSE,7998,2559383,20171015,NA
+1984,"Massachusetts","MA",25,14,3,"US President","Other","",FALSE,843,2559383,20171015,NA
+1984,"Michigan","MI",26,34,23,"US President","Reagan, Ronald","republican",FALSE,2251571,3801658,20171015,NA
+1984,"Michigan","MI",26,34,23,"US President","Mondale, Walter","democrat",FALSE,1529638,3801658,20171015,NA
+1984,"Michigan","MI",26,34,23,"US President","Bergland, David","libertarian",FALSE,10055,3801658,20171015,NA
+1984,"Michigan","MI",26,34,23,"US President","Larouche, Lyndon, Jr.","independent",FALSE,3862,3801658,20171015,NA
+1984,"Michigan","MI",26,34,23,"US President","Holmes, Larry","workers world",FALSE,1416,3801658,20171015,NA
+1984,"Michigan","MI",26,34,23,"US President","Johnson, Sonia","citizens",FALSE,1191,3801658,20171015,NA
+1984,"Michigan","MI",26,34,23,"US President","Mason, Melvin","socialist workers",FALSE,1049,3801658,20171015,NA
+1984,"Michigan","MI",26,34,23,"US President","Hall, Gus","communist party use",FALSE,1048,3801658,20171015,NA
+1984,"Michigan","MI",26,34,23,"US President","Serrette, Dennis","alliance",FALSE,665,3801658,20171015,NA
+1984,"Michigan","MI",26,34,23,"US President","Other","",FALSE,602,3801658,20171015,NA
+1984,"Michigan","MI",26,34,23,"US President","Winn, Edward","workers league",FALSE,561,3801658,20171015,NA
+1984,"Minnesota","MN",27,41,33,"US President","Mondale, Walter","democrat",FALSE,1036364,2084449,20171015,NA
+1984,"Minnesota","MN",27,41,33,"US President","Reagan, Ronald","republican",FALSE,1032603,2084449,20171015,NA
+1984,"Minnesota","MN",27,41,33,"US President","Larouche, Lyndon, Jr.","independent",FALSE,3865,2084449,20171015,NA
+1984,"Minnesota","MN",27,41,33,"US President","Mason, Melvin","socialist workers",FALSE,3180,2084449,20171015,NA
+1984,"Minnesota","MN",27,41,33,"US President","Bergland, David","libertarian",FALSE,2996,2084449,20171015,NA
+1984,"Minnesota","MN",27,41,33,"US President","Richards, Bob","populist",FALSE,2377,2084449,20171015,NA
+1984,"Minnesota","MN",27,41,33,"US President","Johnson, Sonia","citizens",FALSE,1219,2084449,20171015,NA
+1984,"Minnesota","MN",27,41,33,"US President","Other","",FALSE,723,2084449,20171015,NA
+1984,"Minnesota","MN",27,41,33,"US President","Hall, Gus","communist party use",FALSE,630,2084449,20171015,NA
+1984,"Minnesota","MN",27,41,33,"US President","Winn, Edward","workers league",FALSE,260,2084449,20171015,NA
+1984,"Minnesota","MN",27,41,33,"US President","Serrette, Dennis","alliance",FALSE,232,2084449,20171015,NA
+1984,"Mississippi","MS",28,64,46,"US President","Reagan, Ronald","republican",FALSE,582377,941104,20171015,NA
+1984,"Mississippi","MS",28,64,46,"US President","Mondale, Walter","democrat",FALSE,352192,941104,20171015,NA
+1984,"Mississippi","MS",28,64,46,"US President","Bergland, David","libertarian",FALSE,2336,941104,20171015,NA
+1984,"Mississippi","MS",28,64,46,"US President","Holmes, Larry","workers world",FALSE,1169,941104,20171015,NA
+1984,"Mississippi","MS",28,64,46,"US President","Mason, Melvin","socialist workers",FALSE,1032,941104,20171015,NA
+1984,"Mississippi","MS",28,64,46,"US President","Larouche, Lyndon, Jr.","independent",FALSE,1001,941104,20171015,NA
+1984,"Mississippi","MS",28,64,46,"US President","Richards, Bob","populist",FALSE,641,941104,20171015,NA
+1984,"Mississippi","MS",28,64,46,"US President","Serrette, Dennis","alliance",FALSE,356,941104,20171015,NA
+1984,"Missouri","MO",29,43,34,"US President","Reagan, Ronald","republican",FALSE,1274188,2122771,20171015,NA
+1984,"Missouri","MO",29,43,34,"US President","Mondale, Walter","democrat",FALSE,848583,2122771,20171015,NA
+1984,"Montana","MT",30,81,64,"US President","Reagan, Ronald","republican",FALSE,232450,384377,20171015,NA
+1984,"Montana","MT",30,81,64,"US President","Mondale, Walter","democrat",FALSE,146742,384377,20171015,NA
+1984,"Montana","MT",30,81,64,"US President","Bergland, David","libertarian",FALSE,5185,384377,20171015,NA
+1984,"Nebraska","NE",31,46,35,"US President","Reagan, Ronald","republican",FALSE,460054,652090,20171015,NA
+1984,"Nebraska","NE",31,46,35,"US President","Mondale, Walter","democrat",FALSE,187866,652090,20171015,NA
+1984,"Nebraska","NE",31,46,35,"US President","Bergland, David","libertarian",FALSE,2079,652090,20171015,NA
+1984,"Nebraska","NE",31,46,35,"US President","Mason, Melvin","socialist workers",FALSE,1066,652090,20171015,NA
+1984,"Nebraska","NE",31,46,35,"US President","Serrette, Dennis","alliance",FALSE,1025,652090,20171015,NA
+1984,"Nevada","NV",32,88,65,"US President","Reagan, Ronald","republican",FALSE,188770,282717,20171015,NA
+1984,"Nevada","NV",32,88,65,"US President","Mondale, Walter","democrat",FALSE,91655,282717,20171015,NA
+1984,"Nevada","NV",32,88,65,"US President","Bergland, David","libertarian",FALSE,2292,282717,20171015,NA
+1984,"New Hampshire","NH",33,12,4,"US President","Reagan, Ronald","republican",FALSE,267050,388904,20171015,NA
+1984,"New Hampshire","NH",33,12,4,"US President","Mondale, Walter","democrat",FALSE,120347,388904,20171015,NA
+1984,"New Hampshire","NH",33,12,4,"US President","Bergland, David","libertarian",FALSE,735,388904,20171015,NA
+1984,"New Hampshire","NH",33,12,4,"US President","Larouche, Lyndon, Jr.","independent",FALSE,467,388904,20171015,NA
+1984,"New Hampshire","NH",33,12,4,"US President","Serrette, Dennis","alliance",FALSE,305,388904,20171015,NA
+1984,"New Jersey","NJ",34,22,12,"US President","Reagan, Ronald","republican",FALSE,1933630,3217862,20171015,NA
+1984,"New Jersey","NJ",34,22,12,"US President","Mondale, Walter","democrat",FALSE,1261323,3217862,20171015,NA
+1984,"New Jersey","NJ",34,22,12,"US President","Holmes, Larry","workers world",FALSE,8404,3217862,20171015,NA
+1984,"New Jersey","NJ",34,22,12,"US President","Bergland, David","libertarian",FALSE,6416,3217862,20171015,NA
+1984,"New Jersey","NJ",34,22,12,"US President","Serrette, Dennis","alliance",FALSE,2293,3217862,20171015,NA
+1984,"New Jersey","NJ",34,22,12,"US President","Winn, Edward","workers league",FALSE,1721,3217862,20171015,NA
+1984,"New Jersey","NJ",34,22,12,"US President","Hall, Gus","communist party use",FALSE,1564,3217862,20171015,NA
+1984,"New Jersey","NJ",34,22,12,"US President","Mason, Melvin","socialist workers",FALSE,1264,3217862,20171015,NA
+1984,"New Jersey","NJ",34,22,12,"US President","Johnson, Sonia","citizens",FALSE,1247,3217862,20171015,NA
+1984,"New Mexico","NM",35,85,66,"US President","Reagan, Ronald","republican",FALSE,307101,514370,20171015,NA
+1984,"New Mexico","NM",35,85,66,"US President","Mondale, Walter","democrat",FALSE,201769,514370,20171015,NA
+1984,"New Mexico","NM",35,85,66,"US President","Bergland, David","libertarian",FALSE,4459,514370,20171015,NA
+1984,"New Mexico","NM",35,85,66,"US President","Johnson, Sonia","citizens",FALSE,455,514370,20171015,NA
+1984,"New Mexico","NM",35,85,66,"US President","Mason, Melvin","socialist workers",FALSE,224,514370,20171015,NA
+1984,"New Mexico","NM",35,85,66,"US President","Dodge, Earl","prohibition",FALSE,206,514370,20171015,NA
+1984,"New Mexico","NM",35,85,66,"US President","Serrette, Dennis","alliance",FALSE,155,514370,20171015,NA
+1984,"New Mexico","NM",35,85,66,"US President","Other","",FALSE,1,514370,20171015,NA
+1984,"New York","NY",36,21,13,"US President","Reagan, Ronald","republican",FALSE,3376519,6806810,20171015,NA
+1984,"New York","NY",36,21,13,"US President","Mondale, Walter","democrat",FALSE,3001285,6806810,20171015,NA
+1984,"New York","NY",36,21,13,"US President","Reagan, Ronald","conservative",FALSE,288244,6806810,20171015,NA
+1984,"New York","NY",36,21,13,"US President","Mondale, Walter","liberal party",FALSE,118324,6806810,20171015,NA
+1984,"New York","NY",36,21,13,"US President","Bergland, David","libertarian",FALSE,11949,6806810,20171015,NA
+1984,"New York","NY",36,21,13,"US President","Hall, Gus","communist party use",FALSE,4226,6806810,20171015,NA
+1984,"New York","NY",36,21,13,"US President","Serrette, Dennis","alliance",FALSE,3200,6806810,20171015,NA
+1984,"New York","NY",36,21,13,"US President","Holmes, Larry","workers world",FALSE,2226,6806810,20171015,NA
+1984,"New York","NY",36,21,13,"US President","Other","",FALSE,837,6806810,20171015,NA
+1984,"North Carolina","NC",37,56,47,"US President","Reagan, Ronald","republican",FALSE,1346481,2175361,20171015,NA
+1984,"North Carolina","NC",37,56,47,"US President","Mondale, Walter","democrat",FALSE,824287,2175361,20171015,NA
+1984,"North Carolina","NC",37,56,47,"US President","Bergland, David","libertarian",FALSE,3794,2175361,20171015,NA
+1984,"North Carolina","NC",37,56,47,"US President","Mason, Melvin","socialist workers",FALSE,799,2175361,20171015,NA
+1984,"North Dakota","ND",38,44,36,"US President","Reagan, Ronald","republican",FALSE,200336,308971,20171015,NA
+1984,"North Dakota","ND",38,44,36,"US President","Mondale, Walter","democrat",FALSE,104429,308971,20171015,NA
+1984,"North Dakota","ND",38,44,36,"US President","Larouche, Lyndon, Jr.","independent",FALSE,1278,308971,20171015,NA
+1984,"North Dakota","ND",38,44,36,"US President","Richards, Bob","populist",FALSE,1077,308971,20171015,NA
+1984,"North Dakota","ND",38,44,36,"US President","Bergland, David","libertarian",FALSE,703,308971,20171015,NA
+1984,"North Dakota","ND",38,44,36,"US President","Johnson, Sonia","citizens",FALSE,368,308971,20171015,NA
+1984,"North Dakota","ND",38,44,36,"US President","Mason, Melvin","socialist workers",FALSE,239,308971,20171015,NA
+1984,"North Dakota","ND",38,44,36,"US President","Dodge, Earl","prohibition",FALSE,220,308971,20171015,NA
+1984,"North Dakota","ND",38,44,36,"US President","Hall, Gus","communist party use",FALSE,169,308971,20171015,NA
+1984,"North Dakota","ND",38,44,36,"US President","Serrette, Dennis","alliance",FALSE,152,308971,20171015,NA
+1984,"Ohio","OH",39,31,24,"US President","Reagan, Ronald","republican",FALSE,2678559,4563235,20171015,NA
+1984,"Ohio","OH",39,31,24,"US President","Mondale, Walter","democrat",FALSE,1825440,4563235,20171015,NA
+1984,"Ohio","OH",39,31,24,"US President","Serrette, Dennis","alliance",FALSE,24180,4563235,20171015,NA
+1984,"Ohio","OH",39,31,24,"US President","Larouche, Lyndon, Jr.","independent",FALSE,10693,4563235,20171015,NA
+1984,"Ohio","OH",39,31,24,"US President","Winn, Edward","workers league",FALSE,7130,4563235,20171015,NA
+1984,"Ohio","OH",39,31,24,"US President","Bergland, David","libertarian",FALSE,5886,4563235,20171015,NA
+1984,"Ohio","OH",39,31,24,"US President","Hall, Gus","communist party use",FALSE,4438,4563235,20171015,NA
+1984,"Ohio","OH",39,31,24,"US President","Mason, Melvin","socialist workers",FALSE,4344,4563235,20171015,NA
+1984,"Ohio","OH",39,31,24,"US President","Holmes, Larry","workers world",FALSE,2565,4563235,20171015,NA
+1984,"Oklahoma","OK",40,73,53,"US President","Reagan, Ronald","republican",FALSE,861530,1255676,20171015,NA
+1984,"Oklahoma","OK",40,73,53,"US President","Mondale, Walter","democrat",FALSE,385080,1255676,20171015,NA
+1984,"Oklahoma","OK",40,73,53,"US President","Bergland, David","libertarian",FALSE,9066,1255676,20171015,NA
+1984,"Oregon","OR",41,92,72,"US President","Reagan, Ronald","republican",FALSE,685700,1226527,20171015,NA
+1984,"Oregon","OR",41,92,72,"US President","Mondale, Walter","democrat",FALSE,536479,1226527,20171015,NA
+1984,"Oregon","OR",41,92,72,"US President","Other","",FALSE,4348,1226527,20171015,NA
+1984,"Pennsylvania","PA",42,23,14,"US President","Reagan, Ronald","republican",FALSE,2584323,4844903,20171015,NA
+1984,"Pennsylvania","PA",42,23,14,"US President","Mondale, Walter","democrat",FALSE,2228131,4844903,20171015,NA
+1984,"Pennsylvania","PA",42,23,14,"US President","Johnson, Sonia","citizens",FALSE,21628,4844903,20171015,NA
+1984,"Pennsylvania","PA",42,23,14,"US President","Bergland, David","libertarian",FALSE,6982,4844903,20171015,NA
+1984,"Pennsylvania","PA",42,23,14,"US President","Winn, Edward","workers league",FALSE,2059,4844903,20171015,NA
+1984,"Pennsylvania","PA",42,23,14,"US President","Hall, Gus","communist party use",FALSE,1780,4844903,20171015,NA
+1984,"Rhode Island","RI",44,15,5,"US President","Reagan, Ronald","republican",FALSE,212080,410489,20171015,NA
+1984,"Rhode Island","RI",44,15,5,"US President","Mondale, Walter","democrat",FALSE,197106,410489,20171015,NA
+1984,"Rhode Island","RI",44,15,5,"US President","Richards, Bob","populist",FALSE,510,410489,20171015,NA
+1984,"Rhode Island","RI",44,15,5,"US President","Bergland, David","libertarian",FALSE,277,410489,20171015,NA
+1984,"Rhode Island","RI",44,15,5,"US President","Johnson, Sonia","citizens",FALSE,240,410489,20171015,NA
+1984,"Rhode Island","RI",44,15,5,"US President","Holmes, Larry","workers world",FALSE,91,410489,20171015,NA
+1984,"Rhode Island","RI",44,15,5,"US President","Hall, Gus","communist party use",FALSE,75,410489,20171015,NA
+1984,"Rhode Island","RI",44,15,5,"US President","Mason, Melvin","socialist workers",FALSE,61,410489,20171015,NA
+1984,"Rhode Island","RI",44,15,5,"US President","Serrette, Dennis","alliance",FALSE,49,410489,20171015,NA
+1984,"South Carolina","SC",45,57,48,"US President","Reagan, Ronald","republican",FALSE,615539,968529,20171015,NA
+1984,"South Carolina","SC",45,57,48,"US President","Mondale, Walter","democrat",FALSE,344459,968529,20171015,NA
+1984,"South Carolina","SC",45,57,48,"US President","Bergland, David","libertarian",FALSE,4359,968529,20171015,NA
+1984,"South Carolina","SC",45,57,48,"US President","Dennis, Delmar","american",FALSE,3490,968529,20171015,NA
+1984,"South Carolina","SC",45,57,48,"US President","Serrette, Dennis","alliance",FALSE,682,968529,20171015,NA
+1984,"South Dakota","SD",46,45,37,"US President","Reagan, Ronald","republican",FALSE,200267,317867,20171015,NA
+1984,"South Dakota","SD",46,45,37,"US President","Mondale, Walter","democrat",FALSE,116113,317867,20171015,NA
+1984,"South Dakota","SD",46,45,37,"US President","Serrette, Dennis","alliance",FALSE,1150,317867,20171015,NA
+1984,"South Dakota","SD",46,45,37,"US President","Mason, Melvin","socialist workers",FALSE,337,317867,20171015,NA
+1984,"Tennessee","TN",47,62,54,"US President","Reagan, Ronald","republican",FALSE,990212,1711993,20171015,NA
+1984,"Tennessee","TN",47,62,54,"US President","Mondale, Walter","democrat",FALSE,711714,1711993,20171015,NA
+1984,"Tennessee","TN",47,62,54,"US President","Bergland, David","libertarian",FALSE,3072,1711993,20171015,NA
+1984,"Tennessee","TN",47,62,54,"US President","Larouche, Lyndon, Jr.","independent",FALSE,1852,1711993,20171015,NA
+1984,"Tennessee","TN",47,62,54,"US President","Richards, Bob","populist",FALSE,1763,1711993,20171015,NA
+1984,"Tennessee","TN",47,62,54,"US President","Hall, Gus","communist party use",FALSE,1036,1711993,20171015,NA
+1984,"Tennessee","TN",47,62,54,"US President","Johnson, Sonia","citizens",FALSE,978,1711993,20171015,NA
+1984,"Tennessee","TN",47,62,54,"US President","Mason, Melvin","socialist workers",FALSE,715,1711993,20171015,NA
+1984,"Tennessee","TN",47,62,54,"US President","Serrette, Dennis","alliance",FALSE,524,1711993,20171015,NA
+1984,"Tennessee","TN",47,62,54,"US President","Other","",FALSE,127,1711993,20171015,NA
+1984,"Texas","TX",48,74,49,"US President","Reagan, Ronald","republican",FALSE,3433428,5397571,20171015,NA
+1984,"Texas","TX",48,74,49,"US President","Mondale, Walter","democrat",FALSE,1949276,5397571,20171015,NA
+1984,"Texas","TX",48,74,49,"US President","Larouche, Lyndon, Jr.","independent",FALSE,14613,5397571,20171015,NA
+1984,"Texas","TX",48,74,49,"US President","Other","",FALSE,254,5397571,20171015,NA
+1984,"Utah","UT",49,87,67,"US President","Reagan, Ronald","republican",FALSE,469105,629656,20171015,NA
+1984,"Utah","UT",49,87,67,"US President","Mondale, Walter","democrat",FALSE,155369,629656,20171015,NA
+1984,"Utah","UT",49,87,67,"US President","Bergland, David","libertarian",FALSE,2447,629656,20171015,NA
+1984,"Utah","UT",49,87,67,"US President","Dennis, Delmar","american",FALSE,1345,629656,20171015,NA
+1984,"Utah","UT",49,87,67,"US President","Johnson, Sonia","citizens",FALSE,844,629656,20171015,NA
+1984,"Utah","UT",49,87,67,"US President","Serrette, Dennis","alliance",FALSE,220,629656,20171015,NA
+1984,"Utah","UT",49,87,67,"US President","Hall, Gus","communist party use",FALSE,184,629656,20171015,NA
+1984,"Utah","UT",49,87,67,"US President","Mason, Melvin","socialist workers",FALSE,142,629656,20171015,NA
+1984,"Vermont","VT",50,13,6,"US President","Reagan, Ronald","republican",FALSE,135865,234561,20171015,NA
+1984,"Vermont","VT",50,13,6,"US President","Mondale, Walter","democrat",FALSE,95730,234561,20171015,NA
+1984,"Vermont","VT",50,13,6,"US President","Bergland, David","libertarian",FALSE,1002,234561,20171015,NA
+1984,"Vermont","VT",50,13,6,"US President","Other","",FALSE,712,234561,20171015,NA
+1984,"Vermont","VT",50,13,6,"US President","Larouche, Lyndon, Jr.","independent",FALSE,423,234561,20171015,NA
+1984,"Vermont","VT",50,13,6,"US President","Serrette, Dennis","alliance",FALSE,323,234561,20171015,NA
+1984,"Vermont","VT",50,13,6,"US President","Johnson, Sonia","citizens",FALSE,264,234561,20171015,NA
+1984,"Vermont","VT",50,13,6,"US President","Mason, Melvin","socialist workers",FALSE,127,234561,20171015,NA
+1984,"Vermont","VT",50,13,6,"US President","Hall, Gus","communist party use",FALSE,115,234561,20171015,NA
+1984,"Virginia","VA",51,54,40,"US President","Reagan, Ronald","republican",FALSE,1337078,2146635,20171015,NA
+1984,"Virginia","VA",51,54,40,"US President","Mondale, Walter","democrat",FALSE,796250,2146635,20171015,NA
+1984,"Virginia","VA",51,54,40,"US President","Larouche, Lyndon, Jr.","independent",FALSE,13307,2146635,20171015,NA
+1984,"Washington","WA",53,91,73,"US President","Reagan, Ronald","republican",FALSE,1051670,1874910,20171015,NA
+1984,"Washington","WA",53,91,73,"US President","Mondale, Walter","democrat",FALSE,798352,1874910,20171015,NA
+1984,"Washington","WA",53,91,73,"US President","Bergland, David","libertarian",FALSE,8844,1874910,20171015,NA
+1984,"Washington","WA",53,91,73,"US President","Richards, Bob","populist",FALSE,5724,1874910,20171015,NA
+1984,"Washington","WA",53,91,73,"US President","Larouche, Lyndon, Jr.","independent",FALSE,4712,1874910,20171015,NA
+1984,"Washington","WA",53,91,73,"US President","Johnson, Sonia","citizens",FALSE,1891,1874910,20171015,NA
+1984,"Washington","WA",53,91,73,"US President","Serrette, Dennis","alliance",FALSE,1654,1874910,20171015,NA
+1984,"Washington","WA",53,91,73,"US President","Hall, Gus","communist party use",FALSE,814,1874910,20171015,NA
+1984,"Washington","WA",53,91,73,"US President","Holmes, Larry","workers world",FALSE,641,1874910,20171015,NA
+1984,"Washington","WA",53,91,73,"US President","Mason, Melvin","socialist workers",FALSE,608,1874910,20171015,NA
+1984,"West Virginia","WV",54,55,56,"US President","Reagan, Ronald","republican",FALSE,405483,735742,20171015,NA
+1984,"West Virginia","WV",54,55,56,"US President","Mondale, Walter","democrat",FALSE,328125,735742,20171015,NA
+1984,"West Virginia","WV",54,55,56,"US President","Richards, Bob","populist",FALSE,996,735742,20171015,NA
+1984,"West Virginia","WV",54,55,56,"US President","Mason, Melvin","socialist workers",FALSE,645,735742,20171015,NA
+1984,"West Virginia","WV",54,55,56,"US President","Serrette, Dennis","alliance",FALSE,493,735742,20171015,NA
+1984,"Wisconsin","WI",55,35,25,"US President","Reagan, Ronald","republican",FALSE,1198584,2211689,20171015,NA
+1984,"Wisconsin","WI",55,35,25,"US President","Mondale, Walter","democrat",FALSE,995740,2211689,20171015,NA
+1984,"Wisconsin","WI",55,35,25,"US President","Bergland, David","libertarian",FALSE,4883,2211689,20171015,NA
+1984,"Wisconsin","WI",55,35,25,"US President","Richards, Bob","populist",FALSE,3864,2211689,20171015,NA
+1984,"Wisconsin","WI",55,35,25,"US President","Larouche, Lyndon, Jr.","independent",FALSE,3791,2211689,20171015,NA
+1984,"Wisconsin","WI",55,35,25,"US President","Johnson, Sonia","citizens",FALSE,1456,2211689,20171015,NA
+1984,"Wisconsin","WI",55,35,25,"US President","Serrette, Dennis","alliance",FALSE,1006,2211689,20171015,NA
+1984,"Wisconsin","WI",55,35,25,"US President","Other","",FALSE,706,2211689,20171015,NA
+1984,"Wisconsin","WI",55,35,25,"US President","Holmes, Larry","workers world",FALSE,619,2211689,20171015,NA
+1984,"Wisconsin","WI",55,35,25,"US President","Hall, Gus","communist party use",FALSE,596,2211689,20171015,NA
+1984,"Wisconsin","WI",55,35,25,"US President","Mason, Melvin","socialist workers",FALSE,444,2211689,20171015,NA
+1984,"Wyoming","WY",56,83,68,"US President","Reagan, Ronald","republican",FALSE,133241,188968,20171015,NA
+1984,"Wyoming","WY",56,83,68,"US President","Mondale, Walter","democrat",FALSE,53370,188968,20171015,NA
+1984,"Wyoming","WY",56,83,68,"US President","Bergland, David","libertarian",FALSE,2357,188968,20171015,NA
+1988,"Alabama","AL",1,63,41,"US President","Bush, George H.W.","republican",FALSE,815576,1378476,20171015,NA
+1988,"Alabama","AL",1,63,41,"US President","Dukakis, Michael","democrat",FALSE,549506,1378476,20171015,NA
+1988,"Alabama","AL",1,63,41,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,8460,1378476,20171015,NA
+1988,"Alabama","AL",1,63,41,"US President","Winn, Edward","independent",FALSE,4428,1378476,20171015,NA
+1988,"Alabama","AL",1,63,41,"US President","","",TRUE,506,1378476,20171015,NA
+1988,"Alaska","AK",2,94,81,"US President","Bush, George H.W.","republican",FALSE,119251,200116,20171015,NA
+1988,"Alaska","AK",2,94,81,"US President","Dukakis, Michael","democrat",FALSE,72584,200116,20171015,NA
+1988,"Alaska","AK",2,94,81,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,5484,200116,20171015,NA
+1988,"Alaska","AK",2,94,81,"US President","Fulani, Lenora","new alliance",FALSE,1024,200116,20171015,NA
+1988,"Alaska","AK",2,94,81,"US President","","",TRUE,957,200116,20171015,NA
+1988,"Alaska","AK",2,94,81,"US President","Larouche, Lyndon, Jr.","national economic recovery",FALSE,816,200116,20171015,NA
+1988,"Arizona","AZ",4,86,61,"US President","Bush, George H.W.","republican",FALSE,702541,1171873,20171015,NA
+1988,"Arizona","AZ",4,86,61,"US President","Dukakis, Michael","democrat",FALSE,454029,1171873,20171015,NA
+1988,"Arizona","AZ",4,86,61,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,13351,1171873,20171015,NA
+1988,"Arizona","AZ",4,86,61,"US President","Fulani, Lenora","new alliance",FALSE,1662,1171873,20171015,NA
+1988,"Arizona","AZ",4,86,61,"US President","","",TRUE,290,1171873,20171015,NA
+1988,"Arkansas","AR",5,71,42,"US President","Bush, George H.W.","republican",FALSE,466578,827738,20171015,NA
+1988,"Arkansas","AR",5,71,42,"US President","Dukakis, Michael","democrat",FALSE,349237,827738,20171015,NA
+1988,"Arkansas","AR",5,71,42,"US President","Dodge, Earl","populist",FALSE,5146,827738,20171015,NA
+1988,"Arkansas","AR",5,71,42,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,3297,827738,20171015,NA
+1988,"Arkansas","AR",5,71,42,"US President","Fulani, Lenora","new alliance",FALSE,2161,827738,20171015,NA
+1988,"Arkansas","AR",5,71,42,"US President","Dodge, Earl","prohibition",FALSE,1319,827738,20171015,NA
+1988,"California","CA",6,93,71,"US President","Bush, George H.W.","republican",FALSE,5054917,9887065,20171015,NA
+1988,"California","CA",6,93,71,"US President","Dukakis, Michael","democrat",FALSE,4702233,9887065,20171015,NA
+1988,"California","CA",6,93,71,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,70105,9887065,20171015,NA
+1988,"California","CA",6,93,71,"US President","Fulani, Lenora","independent",FALSE,58999,9887065,20171015,NA
+1988,"California","CA",6,93,71,"US President","","",TRUE,811,9887065,20171015,NA
+1988,"Colorado","CO",8,84,62,"US President","Bush, George H.W.","republican",FALSE,728177,1372394,20171015,NA
+1988,"Colorado","CO",8,84,62,"US President","Dukakis, Michael","democrat",FALSE,621453,1372394,20171015,NA
+1988,"Colorado","CO",8,84,62,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,15482,1372394,20171015,NA
+1988,"Colorado","CO",8,84,62,"US President","Dodge, Earl","prohibition",FALSE,4604,1372394,20171015,NA
+1988,"Colorado","CO",8,84,62,"US President","Fulani, Lenora","new alliance",FALSE,2539,1372394,20171015,NA
+1988,"Colorado","CO",8,84,62,"US President","","",TRUE,139,1372394,20171015,NA
+1988,"Connecticut","CT",9,16,1,"US President","Bush, George H.W.","republican",FALSE,750241,1443394,20171015,NA
+1988,"Connecticut","CT",9,16,1,"US President","Dukakis, Michael","democrat",FALSE,676584,1443394,20171015,NA
+1988,"Connecticut","CT",9,16,1,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,14071,1443394,20171015,NA
+1988,"Connecticut","CT",9,16,1,"US President","Fulani, Lenora","new alliance",FALSE,2491,1443394,20171015,NA
+1988,"Connecticut","CT",9,16,1,"US President","","",TRUE,7,1443394,20171015,NA
+1988,"Delaware","DE",10,51,11,"US President","Bush, George H.W.","republican",FALSE,139639,249891,20171015,NA
+1988,"Delaware","DE",10,51,11,"US President","Dukakis, Michael","democrat",FALSE,108647,249891,20171015,NA
+1988,"Delaware","DE",10,51,11,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,1162,249891,20171015,NA
+1988,"Delaware","DE",10,51,11,"US President","Fulani, Lenora","new alliance",FALSE,443,249891,20171015,NA
+1988,"District of Columbia","DC",11,53,55,"US President","Dukakis, Michael","democrat",FALSE,159407,192877,20171015,NA
+1988,"District of Columbia","DC",11,53,55,"US President","Bush, George H.W.","republican",FALSE,27590,192877,20171015,NA
+1988,"District of Columbia","DC",11,53,55,"US President","","independent",FALSE,3064,192877,20171015,NA
+1988,"District of Columbia","DC",11,53,55,"US President","","",TRUE,1553,192877,20171015,NA
+1988,"District of Columbia","DC",11,53,55,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,554,192877,20171015,NA
+1988,"District of Columbia","DC",11,53,55,"US President","","third world assembly",FALSE,236,192877,20171015,NA
+1988,"District of Columbia","DC",11,53,55,"US President","Winn, Edward","workers league",FALSE,208,192877,20171015,NA
+1988,"District of Columbia","DC",11,53,55,"US President","Kenoyer, Willa","socialist",FALSE,142,192877,20171015,NA
+1988,"District of Columbia","DC",11,53,55,"US President","Warren, James """"Mac""""","socialist workers",FALSE,123,192877,20171015,NA
+1988,"Florida","FL",12,59,43,"US President","Bush, George H.W.","republican",FALSE,2618885,4302313,20171015,NA
+1988,"Florida","FL",12,59,43,"US President","Dukakis, Michael","democrat",FALSE,1656701,4302313,20171015,NA
+1988,"Florida","FL",12,59,43,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,19796,4302313,20171015,NA
+1988,"Florida","FL",12,59,43,"US President","Fulani, Lenora","new alliance",FALSE,6655,4302313,20171015,NA
+1988,"Florida","FL",12,59,43,"US President","","",TRUE,276,4302313,20171015,NA
+1988,"Georgia","GA",13,58,44,"US President","Bush, George H.W.","republican",FALSE,1081331,1809672,20171015,NA
+1988,"Georgia","GA",13,58,44,"US President","Dukakis, Michael","democrat",FALSE,714792,1809672,20171015,NA
+1988,"Georgia","GA",13,58,44,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,8435,1809672,20171015,NA
+1988,"Georgia","GA",13,58,44,"US President","Fulani, Lenora","new alliance",FALSE,5099,1809672,20171015,NA
+1988,"Georgia","GA",13,58,44,"US President","","",TRUE,15,1809672,20171015,NA
+1988,"Hawaii","HI",15,95,82,"US President","Dukakis, Michael","democrat",FALSE,192364,354461,20171015,NA
+1988,"Hawaii","HI",15,95,82,"US President","Bush, George H.W.","republican",FALSE,158625,354461,20171015,NA
+1988,"Hawaii","HI",15,95,82,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,1999,354461,20171015,NA
+1988,"Hawaii","HI",15,95,82,"US President","Fulani, Lenora","no party affiliation",FALSE,1003,354461,20171015,NA
+1988,"Hawaii","HI",15,95,82,"US President","Larouche, Lyndon, Jr.","national economic recovery",FALSE,470,354461,20171015,NA
+1988,"Idaho","ID",16,82,63,"US President","Bush, George H.W.","republican",FALSE,253881,408968,20171015,NA
+1988,"Idaho","ID",16,82,63,"US President","Dukakis, Michael","democrat",FALSE,147272,408968,20171015,NA
+1988,"Idaho","ID",16,82,63,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,5313,408968,20171015,NA
+1988,"Idaho","ID",16,82,63,"US President","Fulani, Lenora","independent",FALSE,2502,408968,20171015,NA
+1988,"Illinois","IL",17,33,21,"US President","Bush, George H.W.","republican",FALSE,2310939,4559120,20171015,NA
+1988,"Illinois","IL",17,33,21,"US President","Dukakis, Michael","democrat",FALSE,2215940,4559120,20171015,NA
+1988,"Illinois","IL",17,33,21,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,14944,4559120,20171015,NA
+1988,"Illinois","IL",17,33,21,"US President","Fulani, Lenora","solidarity",FALSE,10276,4559120,20171015,NA
+1988,"Illinois","IL",17,33,21,"US President","Winn, Edward","independent",FALSE,7021,4559120,20171015,NA
+1988,"Indiana","IN",18,32,22,"US President","Bush, George H.W.","republican",FALSE,1297763,2168621,20171015,NA
+1988,"Indiana","IN",18,32,22,"US President","Dukakis, Michael","democrat",FALSE,860643,2168621,20171015,NA
+1988,"Indiana","IN",18,32,22,"US President","Fulani, Lenora","new alliance",FALSE,10215,2168621,20171015,NA
+1988,"Iowa","IA",19,42,31,"US President","Dukakis, Michael","democrat",FALSE,670557,1225614,20171015,NA
+1988,"Iowa","IA",19,42,31,"US President","Bush, George H.W.","republican",FALSE,545355,1225614,20171015,NA
+1988,"Iowa","IA",19,42,31,"US President","Larouche, Lyndon, Jr.","nominated by petition",FALSE,3526,1225614,20171015,NA
+1988,"Iowa","IA",19,42,31,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,2494,1225614,20171015,NA
+1988,"Iowa","IA",19,42,31,"US President","Scattering","",FALSE,1613,1225614,20171015,NA
+1988,"Iowa","IA",19,42,31,"US President","Duke, David","patriotic party",FALSE,755,1225614,20171015,NA
+1988,"Iowa","IA",19,42,31,"US President","Fulani, Lenora","new alliance",FALSE,540,1225614,20171015,NA
+1988,"Iowa","IA",19,42,31,"US President","Kenoyer, Willa","socialist",FALSE,334,1225614,20171015,NA
+1988,"Iowa","IA",19,42,31,"US President","Winn, Edward","workers league",FALSE,235,1225614,20171015,NA
+1988,"Iowa","IA",19,42,31,"US President","Warren, James """"Mac""""","socialist workers",FALSE,205,1225614,20171015,NA
+1988,"Kansas","KS",20,47,32,"US President","Bush, George H.W.","republican",FALSE,554049,993044,20171015,NA
+1988,"Kansas","KS",20,47,32,"US President","Dukakis, Michael","democrat",FALSE,422636,993044,20171015,NA
+1988,"Kansas","KS",20,47,32,"US President","","independent",FALSE,16359,993044,20171015,NA
+1988,"Kentucky","KY",21,61,51,"US President","Bush, George H.W.","republican",FALSE,734281,1322517,20171015,NA
+1988,"Kentucky","KY",21,61,51,"US President","Dukakis, Michael","democrat",FALSE,580368,1322517,20171015,NA
+1988,"Kentucky","KY",21,61,51,"US President","Duke, David","populist",FALSE,4494,1322517,20171015,NA
+1988,"Kentucky","KY",21,61,51,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,2118,1322517,20171015,NA
+1988,"Kentucky","KY",21,61,51,"US President","Fulani, Lenora","new alliance",FALSE,1256,1322517,20171015,NA
+1988,"Louisiana","LA",22,72,45,"US President","Bush, George H.W.","republican",FALSE,883702,1628202,20171015,NA
+1988,"Louisiana","LA",22,72,45,"US President","Dukakis, Michael","democrat",FALSE,717460,1628202,20171015,NA
+1988,"Louisiana","LA",22,72,45,"US President","Duke, David","populist",FALSE,18612,1628202,20171015,NA
+1988,"Louisiana","LA",22,72,45,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,4115,1628202,20171015,NA
+1988,"Louisiana","LA",22,72,45,"US President","Fulani, Lenora","new alliance",FALSE,2355,1628202,20171015,NA
+1988,"Louisiana","LA",22,72,45,"US President","Larouche, Lyndon, Jr.","national economic recovery",FALSE,1958,1628202,20171015,NA
+1988,"Maine","ME",23,11,2,"US President","Bush, George H.W.","republican",FALSE,307131,555035,20171015,NA
+1988,"Maine","ME",23,11,2,"US President","Dukakis, Michael","democrat",FALSE,243569,555035,20171015,NA
+1988,"Maine","ME",23,11,2,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,2700,555035,20171015,NA
+1988,"Maine","ME",23,11,2,"US President","Fulani, Lenora","new alliance",FALSE,1405,555035,20171015,NA
+1988,"Maine","ME",23,11,2,"US President","","other",FALSE,230,555035,20171015,NA
+1988,"Maryland","MD",24,52,52,"US President","Bush, George H.W.","republican",FALSE,876167,1714358,20171015,NA
+1988,"Maryland","MD",24,52,52,"US President","Dukakis, Michael","democrat",FALSE,826304,1714358,20171015,NA
+1988,"Maryland","MD",24,52,52,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,6748,1714358,20171015,NA
+1988,"Maryland","MD",24,52,52,"US President","Fulani, Lenora","new alliance",FALSE,5115,1714358,20171015,NA
+1988,"Maryland","MD",24,52,52,"US President","","",TRUE,24,1714358,20171015,NA
+1988,"Massachusetts","MA",25,14,3,"US President","Dukakis, Michael","democrat",FALSE,1401415,2632801,20171015,NA
+1988,"Massachusetts","MA",25,14,3,"US President","Bush, George H.W.","republican",FALSE,1194635,2632801,20171015,NA
+1988,"Massachusetts","MA",25,14,3,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,24251,2632801,20171015,NA
+1988,"Massachusetts","MA",25,14,3,"US President","Fulani, Lenora","new alliance",FALSE,9561,2632801,20171015,NA
+1988,"Massachusetts","MA",25,14,3,"US President","","other",FALSE,2939,2632801,20171015,NA
+1988,"Michigan","MI",26,34,23,"US President","Bush, George H.W.","republican",FALSE,1965486,3669163,20171015,NA
+1988,"Michigan","MI",26,34,23,"US President","Dukakis, Michael","democrat",FALSE,1675783,3669163,20171015,NA
+1988,"Michigan","MI",26,34,23,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,18336,3669163,20171015,NA
+1988,"Michigan","MI",26,34,23,"US President","","other",FALSE,7600,3669163,20171015,NA
+1988,"Michigan","MI",26,34,23,"US President","Winn, Edward","workers league",FALSE,1958,3669163,20171015,NA
+1988,"Minnesota","MN",27,41,33,"US President","Dukakis, Michael","democrat",FALSE,1109471,2096790,20171015,NA
+1988,"Minnesota","MN",27,41,33,"US President","Bush, George H.W.","republican",FALSE,962337,2096790,20171015,NA
+1988,"Minnesota","MN",27,41,33,"US President","McCarthy, Eugene """"Gene""""","progressive",FALSE,5403,2096790,20171015,NA
+1988,"Minnesota","MN",27,41,33,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,5109,2096790,20171015,NA
+1988,"Minnesota","MN",27,41,33,"US President","","",TRUE,3614,2096790,20171015,NA
+1988,"Minnesota","MN",27,41,33,"US President","Warren, James """"Mac""""","socialist workers",FALSE,2155,2096790,20171015,NA
+1988,"Minnesota","MN",27,41,33,"US President","Herer, Jack","grassroots",FALSE,1949,2096790,20171015,NA
+1988,"Minnesota","MN",27,41,33,"US President","Fulani, Lenora","new alliance",FALSE,1734,2096790,20171015,NA
+1988,"Minnesota","MN",27,41,33,"US President","Larouche, Lyndon, Jr.","national economic recovery",FALSE,1702,2096790,20171015,NA
+1988,"Minnesota","MN",27,41,33,"US President","Duke, David","populist",FALSE,1529,2096790,20171015,NA
+1988,"Minnesota","MN",27,41,33,"US President","Dennis, Delmar","american",FALSE,1298,2096790,20171015,NA
+1988,"Minnesota","MN",27,41,33,"US President","Winn, Edward","workers league",FALSE,489,2096790,20171015,NA
+1988,"Mississippi","MS",28,64,46,"US President","Bush, George H.W.","republican",FALSE,557890,931527,20171015,NA
+1988,"Mississippi","MS",28,64,46,"US President","Dukakis, Michael","democrat",FALSE,363921,931527,20171015,NA
+1988,"Mississippi","MS",28,64,46,"US President","","independent",FALSE,6387,931527,20171015,NA
+1988,"Mississippi","MS",28,64,46,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,3329,931527,20171015,NA
+1988,"Missouri","MO",29,43,34,"US President","Bush, George H.W.","republican",FALSE,1084953,2093228,20171015,NA
+1988,"Missouri","MO",29,43,34,"US President","Dukakis, Michael","democrat",FALSE,1001619,2093228,20171015,NA
+1988,"Missouri","MO",29,43,34,"US President","Fulani, Lenora","new alliance",FALSE,6656,2093228,20171015,NA
+1988,"Montana","MT",30,81,64,"US President","Bush, George H.W.","republican",FALSE,190412,365674,20171015,NA
+1988,"Montana","MT",30,81,64,"US President","Dukakis, Michael","democrat",FALSE,168936,365674,20171015,NA
+1988,"Montana","MT",30,81,64,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,5047,365674,20171015,NA
+1988,"Montana","MT",30,81,64,"US President","Fulani, Lenora","new alliance",FALSE,1279,365674,20171015,NA
+1988,"Nebraska","NE",31,46,35,"US President","Bush, George H.W.","republican",FALSE,397956,661465,20171015,NA
+1988,"Nebraska","NE",31,46,35,"US President","Dukakis, Michael","democrat",FALSE,259235,661465,20171015,NA
+1988,"Nebraska","NE",31,46,35,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,2534,661465,20171015,NA
+1988,"Nebraska","NE",31,46,35,"US President","Fulani, Lenora","new alliance",FALSE,1740,661465,20171015,NA
+1988,"Nevada","NV",32,88,65,"US President","Bush, George H.W.","republican",FALSE,206040,343133,20171015,NA
+1988,"Nevada","NV",32,88,65,"US President","Dukakis, Michael","democrat",FALSE,132738,343133,20171015,NA
+1988,"Nevada","NV",32,88,65,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,3520,343133,20171015,NA
+1988,"Nevada","NV",32,88,65,"US President","Fulani, Lenora","new alliance",FALSE,835,343133,20171015,NA
+1988,"New Hampshire","NH",33,12,4,"US President","Bush, George H.W.","republican",FALSE,281537,450525,20171015,NA
+1988,"New Hampshire","NH",33,12,4,"US President","Dukakis, Michael","democrat",FALSE,163696,450525,20171015,NA
+1988,"New Hampshire","NH",33,12,4,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,4502,450525,20171015,NA
+1988,"New Hampshire","NH",33,12,4,"US President","Fulani, Lenora","new alliance",FALSE,790,450525,20171015,NA
+1988,"New Jersey","NJ",34,22,12,"US President","Bush, George H.W.","republican",FALSE,1743192,3099553,20171015,NA
+1988,"New Jersey","NJ",34,22,12,"US President","Dukakis, Michael","democrat",FALSE,1320352,3099553,20171015,NA
+1988,"New Jersey","NJ",34,22,12,"US President","Herberg G., Lewin","peace & freedom",FALSE,9953,3099553,20171015,NA
+1988,"New Jersey","NJ",34,22,12,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,8421,3099553,20171015,NA
+1988,"New Jersey","NJ",34,22,12,"US President","Fulani, Lenora","new alliance",FALSE,5139,3099553,20171015,NA
+1988,"New Jersey","NJ",34,22,12,"US President","McCarthy, Eugene """"Gene""""","consumer",FALSE,3454,3099553,20171015,NA
+1988,"New Jersey","NJ",34,22,12,"US President","Kenoyer, Willa","socialist",FALSE,2587,3099553,20171015,NA
+1988,"New Jersey","NJ",34,22,12,"US President","Duke, David","populist",FALSE,2446,3099553,20171015,NA
+1988,"New Jersey","NJ",34,22,12,"US President","Warren, James """"Mac""""","socialist workers",FALSE,2298,3099553,20171015,NA
+1988,"New Jersey","NJ",34,22,12,"US President","Holmes, Larry","workers world",FALSE,1020,3099553,20171015,NA
+1988,"New Jersey","NJ",34,22,12,"US President","Winn, Edward","workers league",FALSE,691,3099553,20171015,NA
+1988,"New Mexico","NM",35,85,66,"US President","Bush, George H.W.","republican",FALSE,270341,521387,20171015,NA
+1988,"New Mexico","NM",35,85,66,"US President","Dukakis, Michael","democrat",FALSE,244497,521387,20171015,NA
+1988,"New Mexico","NM",35,85,66,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,3368,521387,20171015,NA
+1988,"New Mexico","NM",35,85,66,"US President","Fulani, Lenora","new alliance",FALSE,2237,521387,20171015,NA
+1988,"New Mexico","NM",35,85,66,"US President","Warren, James """"Mac""""","socialist workers",FALSE,344,521387,20171015,NA
+1988,"New Mexico","NM",35,85,66,"US President","Holmes, Larry","workers world",FALSE,258,521387,20171015,NA
+1988,"New Mexico","NM",35,85,66,"US President","Dodge, Earl","prohibition",FALSE,249,521387,20171015,NA
+1988,"New Mexico","NM",35,85,66,"US President","","write-in",TRUE,93,521387,20171015,NA
+1988,"New York","NY",36,21,13,"US President","Dukakis, Michael","democrat",FALSE,3255487,6485683,20171015,NA
+1988,"New York","NY",36,21,13,"US President","Bush, George H.W.","republican",FALSE,2838414,6485683,20171015,NA
+1988,"New York","NY",36,21,13,"US President","Bush, George H.W.","conservative",FALSE,243457,6485683,20171015,NA
+1988,"New York","NY",36,21,13,"US President","Dukakis, Michael","liberal party",FALSE,92395,6485683,20171015,NA
+1988,"New York","NY",36,21,13,"US President","Marra, William A.","right-to-life",FALSE,20497,6485683,20171015,NA
+1988,"New York","NY",36,21,13,"US President","Fulani, Lenora","new alliance",FALSE,15845,6485683,20171015,NA
+1988,"New York","NY",36,21,13,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,12109,6485683,20171015,NA
+1988,"New York","NY",36,21,13,"US President","Holmes, Larry","workers world",FALSE,4179,6485683,20171015,NA
+1988,"New York","NY",36,21,13,"US President","Warren, James """"Mac""""","socialist workers",FALSE,3287,6485683,20171015,NA
+1988,"New York","NY",36,21,13,"US President","","other",FALSE,13,6485683,20171015,NA
+1988,"North Carolina","NC",37,56,47,"US President","Bush, George H.W.","republican",FALSE,1237258,2134370,20171015,NA
+1988,"North Carolina","NC",37,56,47,"US President","Dukakis, Michael","democrat",FALSE,890167,2134370,20171015,NA
+1988,"North Carolina","NC",37,56,47,"US President","Fulani, Lenora","new alliance",FALSE,5682,2134370,20171015,NA
+1988,"North Carolina","NC",37,56,47,"US President","Paul, Ronald """"Ron""""","",TRUE,1263,2134370,20171015,NA
+1988,"North Dakota","ND",38,44,36,"US President","Bush, George H.W.","republican",FALSE,166559,297261,20171015,NA
+1988,"North Dakota","ND",38,44,36,"US President","Dukakis, Michael","democrat",FALSE,127739,297261,20171015,NA
+1988,"North Dakota","ND",38,44,36,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,1315,297261,20171015,NA
+1988,"North Dakota","ND",38,44,36,"US President","Larouche, Lyndon, Jr.","national economic recovery",FALSE,905,297261,20171015,NA
+1988,"North Dakota","ND",38,44,36,"US President","Fulani, Lenora","new alliance",FALSE,396,297261,20171015,NA
+1988,"North Dakota","ND",38,44,36,"US President","Warren, James """"Mac""""","socialist workers",FALSE,347,297261,20171015,NA
+1988,"Ohio","OH",39,31,24,"US President","Bush, George H.W.","republican",FALSE,2416549,4393585,20171015,NA
+1988,"Ohio","OH",39,31,24,"US President","Dukakis, Michael","democrat",FALSE,1939629,4393585,20171015,NA
+1988,"Ohio","OH",39,31,24,"US President","Fulani, Lenora","new alliance",FALSE,12017,4393585,20171015,NA
+1988,"Ohio","OH",39,31,24,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,11926,4393585,20171015,NA
+1988,"Ohio","OH",39,31,24,"US President","","independent",FALSE,7713,4393585,20171015,NA
+1988,"Ohio","OH",39,31,24,"US President","Winn, Edward","workers league",FALSE,5401,4393585,20171015,NA
+1988,"Ohio","OH",39,31,24,"US President","","",TRUE,350,4393585,20171015,NA
+1988,"Oklahoma","OK",40,73,53,"US President","Bush, George H.W.","republican",FALSE,678367,1171036,20171015,NA
+1988,"Oklahoma","OK",40,73,53,"US President","Dukakis, Michael","democrat",FALSE,483423,1171036,20171015,NA
+1988,"Oklahoma","OK",40,73,53,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,6261,1171036,20171015,NA
+1988,"Oklahoma","OK",40,73,53,"US President","Fulani, Lenora","new alliance",FALSE,2985,1171036,20171015,NA
+1988,"Oregon","OR",41,92,72,"US President","Dukakis, Michael","democrat",FALSE,616206,1201694,20171015,NA
+1988,"Oregon","OR",41,92,72,"US President","Bush, George H.W.","republican",FALSE,560126,1201694,20171015,NA
+1988,"Oregon","OR",41,92,72,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,14811,1201694,20171015,NA
+1988,"Oregon","OR",41,92,72,"US President","Fulani, Lenora","independent",FALSE,6487,1201694,20171015,NA
+1988,"Oregon","OR",41,92,72,"US President","","other",FALSE,4064,1201694,20171015,NA
+1988,"Pennsylvania","PA",42,23,14,"US President","Bush, George H.W.","republican",FALSE,2300087,4536251,20171015,NA
+1988,"Pennsylvania","PA",42,23,14,"US President","Dukakis, Michael","democrat",FALSE,2194944,4536251,20171015,NA
+1988,"Pennsylvania","PA",42,23,14,"US President","McCarthy, Eugene """"Gene""""","consumer",FALSE,19158,4536251,20171015,NA
+1988,"Pennsylvania","PA",42,23,14,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,12051,4536251,20171015,NA
+1988,"Pennsylvania","PA",42,23,14,"US President","Fulani, Lenora","new alliance",FALSE,4379,4536251,20171015,NA
+1988,"Pennsylvania","PA",42,23,14,"US President","Duke, David","populist",FALSE,3444,4536251,20171015,NA
+1988,"Pennsylvania","PA",42,23,14,"US President","Winn, Edward","workers league",FALSE,2188,4536251,20171015,NA
+1988,"Rhode Island","RI",44,15,5,"US President","Dukakis, Michael","democrat",FALSE,225123,404622,20171015,NA
+1988,"Rhode Island","RI",44,15,5,"US President","Bush, George H.W.","republican",FALSE,177761,404622,20171015,NA
+1988,"Rhode Island","RI",44,15,5,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,825,404622,20171015,NA
+1988,"Rhode Island","RI",44,15,5,"US President","Fulani, Lenora","new alliance",FALSE,280,404622,20171015,NA
+1988,"Rhode Island","RI",44,15,5,"US President","Herberg G., Lewin","peace & freedom",FALSE,195,404622,20171015,NA
+1988,"Rhode Island","RI",44,15,5,"US President","Duke, David","populist",FALSE,159,404622,20171015,NA
+1988,"Rhode Island","RI",44,15,5,"US President","Warren, James """"Mac""""","socialist workers",FALSE,130,404622,20171015,NA
+1988,"Rhode Island","RI",44,15,5,"US President","Kenoyer, Willa","socialist",FALSE,96,404622,20171015,NA
+1988,"Rhode Island","RI",44,15,5,"US President","","",TRUE,53,404622,20171015,NA
+1988,"South Carolina","SC",45,57,48,"US President","Bush, George H.W.","republican",FALSE,606443,986009,20171015,NA
+1988,"South Carolina","SC",45,57,48,"US President","Dukakis, Michael","democrat",FALSE,370554,986009,20171015,NA
+1988,"South Carolina","SC",45,57,48,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,4935,986009,20171015,NA
+1988,"South Carolina","SC",45,57,48,"US President","Fulani, Lenora","united citizens",FALSE,4077,986009,20171015,NA
+1988,"South Dakota","SD",46,45,37,"US President","Bush, George H.W.","republican",FALSE,165415,312991,20171015,NA
+1988,"South Dakota","SD",46,45,37,"US President","Dukakis, Michael","democrat",FALSE,145560,312991,20171015,NA
+1988,"South Dakota","SD",46,45,37,"US President","","independent",FALSE,2016,312991,20171015,NA
+1988,"Tennessee","TN",47,62,54,"US President","Bush, George H.W.","republican",FALSE,947233,1636250,20171015,NA
+1988,"Tennessee","TN",47,62,54,"US President","Dukakis, Michael","democrat",FALSE,679794,1636250,20171015,NA
+1988,"Tennessee","TN",47,62,54,"US President","","independent",FALSE,8938,1636250,20171015,NA
+1988,"Tennessee","TN",47,62,54,"US President","","",TRUE,285,1636250,20171015,NA
+1988,"Texas","TX",48,74,49,"US President","Bush, George H.W.","republican",FALSE,3036829,5427410,20171015,NA
+1988,"Texas","TX",48,74,49,"US President","Dukakis, Michael","democrat",FALSE,2352748,5427410,20171015,NA
+1988,"Texas","TX",48,74,49,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,30355,5427410,20171015,NA
+1988,"Texas","TX",48,74,49,"US President","Fulani, Lenora","new alliance",FALSE,7208,5427410,20171015,NA
+1988,"Texas","TX",48,74,49,"US President","","",TRUE,270,5427410,20171015,NA
+1988,"Utah","UT",49,87,67,"US President","Bush, George H.W.","republican",FALSE,428442,647008,20171015,NA
+1988,"Utah","UT",49,87,67,"US President","Dukakis, Michael","democrat",FALSE,207343,647008,20171015,NA
+1988,"Utah","UT",49,87,67,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,7473,647008,20171015,NA
+1988,"Utah","UT",49,87,67,"US President","Dennis, Delmar","american",FALSE,2158,647008,20171015,NA
+1988,"Utah","UT",49,87,67,"US President","Fulani, Lenora","new alliance",FALSE,455,647008,20171015,NA
+1988,"Utah","UT",49,87,67,"US President","Larouche, Lyndon, Jr.","national economic recovery",FALSE,427,647008,20171015,NA
+1988,"Utah","UT",49,87,67,"US President","Youngkeit, Louie G.","independent",FALSE,372,647008,20171015,NA
+1988,"Utah","UT",49,87,67,"US President","Warren, James """"Mac""""","socialist workers",FALSE,209,647008,20171015,NA
+1988,"Utah","UT",49,87,67,"US President","Kenoyer, Willa","socialist",FALSE,129,647008,20171015,NA
+1988,"Vermont","VT",50,13,6,"US President","Bush, George H.W.","republican",FALSE,124331,243328,20171015,NA
+1988,"Vermont","VT",50,13,6,"US President","Dukakis, Michael","democrat",FALSE,115775,243328,20171015,NA
+1988,"Vermont","VT",50,13,6,"US President","Scattering","",FALSE,1134,243328,20171015,NA
+1988,"Vermont","VT",50,13,6,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,1000,243328,20171015,NA
+1988,"Vermont","VT",50,13,6,"US President","Larouche, Lyndon, Jr.","independent",FALSE,275,243328,20171015,NA
+1988,"Vermont","VT",50,13,6,"US President","Fulani, Lenora","new alliance",FALSE,205,243328,20171015,NA
+1988,"Vermont","VT",50,13,6,"US President","Duke, David","populist",FALSE,189,243328,20171015,NA
+1988,"Vermont","VT",50,13,6,"US President","Herberg G., Lewin","peace & freedom",FALSE,164,243328,20171015,NA
+1988,"Vermont","VT",50,13,6,"US President","Kenoyer, Willa","liberty union party",FALSE,142,243328,20171015,NA
+1988,"Vermont","VT",50,13,6,"US President","Warren, James """"Mac""""","socialist workers",FALSE,113,243328,20171015,NA
+1988,"Virginia","VA",51,54,40,"US President","Bush, George H.W.","republican",FALSE,1309162,2191609,20171015,NA
+1988,"Virginia","VA",51,54,40,"US President","Dukakis, Michael","democrat",FALSE,859799,2191609,20171015,NA
+1988,"Virginia","VA",51,54,40,"US President","Fulani, Lenora","independent",FALSE,14312,2191609,20171015,NA
+1988,"Virginia","VA",51,54,40,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,8336,2191609,20171015,NA
+1988,"Washington","WA",53,91,73,"US President","Dukakis, Michael","democrat",FALSE,933516,1865253,20171015,NA
+1988,"Washington","WA",53,91,73,"US President","Bush, George H.W.","republican",FALSE,903835,1865253,20171015,NA
+1988,"Washington","WA",53,91,73,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,17240,1865253,20171015,NA
+1988,"Washington","WA",53,91,73,"US President","Larouche, Lyndon, Jr.","independent",FALSE,4412,1865253,20171015,NA
+1988,"Washington","WA",53,91,73,"US President","Fulani, Lenora","new alliance",FALSE,3520,1865253,20171015,NA
+1988,"Washington","WA",53,91,73,"US President","Holmes, Larry","workers world",FALSE,1440,1865253,20171015,NA
+1988,"Washington","WA",53,91,73,"US President","Warren, James """"Mac""""","socialist workers",FALSE,1290,1865253,20171015,NA
+1988,"West Virginia","WV",54,55,56,"US President","Dukakis, Michael","democrat",FALSE,341016,653311,20171015,NA
+1988,"West Virginia","WV",54,55,56,"US President","Bush, George H.W.","republican",FALSE,310065,653311,20171015,NA
+1988,"West Virginia","WV",54,55,56,"US President","Fulani, Lenora","new alliance",FALSE,2230,653311,20171015,NA
+1988,"Wisconsin","WI",55,35,25,"US President","Dukakis, Michael","democrat",FALSE,1126794,2191608,20171015,NA
+1988,"Wisconsin","WI",55,35,25,"US President","Bush, George H.W.","republican",FALSE,1047499,2191608,20171015,NA
+1988,"Wisconsin","WI",55,35,25,"US President","","independent",FALSE,15042,2191608,20171015,NA
+1988,"Wisconsin","WI",55,35,25,"US President","Scattering","",FALSE,2273,2191608,20171015,NA
+1988,"Wyoming","WY",56,83,68,"US President","Bush, George H.W.","republican",FALSE,106867,176551,20171015,NA
+1988,"Wyoming","WY",56,83,68,"US President","Dukakis, Michael","democrat",FALSE,67113,176551,20171015,NA
+1988,"Wyoming","WY",56,83,68,"US President","Paul, Ronald """"Ron""""","libertarian",FALSE,2026,176551,20171015,NA
+1988,"Wyoming","WY",56,83,68,"US President","Fulani, Lenora","new alliance",FALSE,545,176551,20171015,NA
+1992,"Alabama","AL",1,63,41,"US President","Bush, George H.W.","republican",FALSE,804283,1688060,20171015,NA
+1992,"Alabama","AL",1,63,41,"US President","Clinton, Bill","democrat",FALSE,690080,1688060,20171015,NA
+1992,"Alabama","AL",1,63,41,"US President","Perot, Ross","independent",FALSE,183109,1688060,20171015,NA
+1992,"Alabama","AL",1,63,41,"US President","Marrou, Andre","libertarian",FALSE,5737,1688060,20171015,NA
+1992,"Alabama","AL",1,63,41,"US President","Other","independent",FALSE,4128,1688060,20171015,NA
+1992,"Alabama","AL",1,63,41,"US President","","",TRUE,723,1688060,20171015,NA
+1992,"Alaska","AK",2,94,81,"US President","Bush, George H.W.","republican",FALSE,102000,258506,20171015,NA
+1992,"Alaska","AK",2,94,81,"US President","Clinton, Bill","democrat",FALSE,78294,258506,20171015,NA
+1992,"Alaska","AK",2,94,81,"US President","Perot, Ross","independent",FALSE,73481,258506,20171015,NA
+1992,"Alaska","AK",2,94,81,"US President","Gritz, James """"Bo""""","america first",FALSE,1379,258506,20171015,NA
+1992,"Alaska","AK",2,94,81,"US President","Marrou, Andre","libertarian",FALSE,1378,258506,20171015,NA
+1992,"Alaska","AK",2,94,81,"US President","Larouche, Lyndon, Jr.","independents for economic recovery",FALSE,469,258506,20171015,NA
+1992,"Alaska","AK",2,94,81,"US President","Hagelin, John","natural law",FALSE,433,258506,20171015,NA
+1992,"Alaska","AK",2,94,81,"US President","Phillips, Howard","taxpayers party",FALSE,377,258506,20171015,NA
+1992,"Alaska","AK",2,94,81,"US President","","",TRUE,365,258506,20171015,NA
+1992,"Alaska","AK",2,94,81,"US President","Fulani, Lenora","new alliance",FALSE,330,258506,20171015,NA
+1992,"Arizona","AZ",4,86,61,"US President","Bush, George H.W.","republican",FALSE,572086,1486975,20171015,NA
+1992,"Arizona","AZ",4,86,61,"US President","Clinton, Bill","democrat",FALSE,543050,1486975,20171015,NA
+1992,"Arizona","AZ",4,86,61,"US President","Perot, Ross","independent",FALSE,353741,1486975,20171015,NA
+1992,"Arizona","AZ",4,86,61,"US President","Gritz, James """"Bo""""","independent",FALSE,8141,1486975,20171015,NA
+1992,"Arizona","AZ",4,86,61,"US President","Marrou, Andre","libertarian",FALSE,6759,1486975,20171015,NA
+1992,"Arizona","AZ",4,86,61,"US President","Hagelin, John","natural law",FALSE,2267,1486975,20171015,NA
+1992,"Arizona","AZ",4,86,61,"US President","Fulani, Lenora","new alliance",FALSE,923,1486975,20171015,NA
+1992,"Arizona","AZ",4,86,61,"US President","","",TRUE,8,1486975,20171015,NA
+1992,"Arkansas","AR",5,71,42,"US President","Clinton, Bill","democrat",FALSE,505823,950653,20171015,NA
+1992,"Arkansas","AR",5,71,42,"US President","Bush, George H.W.","republican",FALSE,337324,950653,20171015,NA
+1992,"Arkansas","AR",5,71,42,"US President","Perot, Ross","independent",FALSE,99132,950653,20171015,NA
+1992,"Arkansas","AR",5,71,42,"US President","Other","independent",FALSE,8374,950653,20171015,NA
+1992,"California","CA",6,93,71,"US President","Clinton, Bill","democrat",FALSE,5121325,11131721,20171015,NA
+1992,"California","CA",6,93,71,"US President","Bush, George H.W.","republican",FALSE,3630574,11131721,20171015,NA
+1992,"California","CA",6,93,71,"US President","Perot, Ross","independent",FALSE,2296006,11131721,20171015,NA
+1992,"California","CA",6,93,71,"US President","Marrou, Andre","libertarian",FALSE,48139,11131721,20171015,NA
+1992,"California","CA",6,93,71,"US President","Daniels, Ron","peace & freedom",FALSE,18597,11131721,20171015,NA
+1992,"California","CA",6,93,71,"US President","Phillips, Howard","american independent party",FALSE,12711,11131721,20171015,NA
+1992,"California","CA",6,93,71,"US President","","",TRUE,4369,11131721,20171015,NA
+1992,"Colorado","CO",8,84,62,"US President","Clinton, Bill","democrat",FALSE,629681,1569180,20171015,NA
+1992,"Colorado","CO",8,84,62,"US President","Bush, George H.W.","republican",FALSE,562850,1569180,20171015,NA
+1992,"Colorado","CO",8,84,62,"US President","Perot, Ross","independent",FALSE,366010,1569180,20171015,NA
+1992,"Colorado","CO",8,84,62,"US President","Marrou, Andre","libertarian",FALSE,8669,1569180,20171015,NA
+1992,"Colorado","CO",8,84,62,"US President","Fulani, Lenora","new alliance",FALSE,1608,1569180,20171015,NA
+1992,"Colorado","CO",8,84,62,"US President","Gritz, James """"Bo""""","democrat/republican",FALSE,274,1569180,20171015,NA
+1992,"Colorado","CO",8,84,62,"US President","Hagelin, John","natural law",FALSE,47,1569180,20171015,NA
+1992,"Colorado","CO",8,84,62,"US President","Prohibition","prohibition",FALSE,21,1569180,20171015,NA
+1992,"Colorado","CO",8,84,62,"US President","Unaffiliated","unaffiliated",FALSE,20,1569180,20171015,NA
+1992,"Connecticut","CT",9,16,1,"US President","Clinton, Bill","democrat",FALSE,682318,1616156,20171015,NA
+1992,"Connecticut","CT",9,16,1,"US President","Bush, George H.W.","republican",FALSE,578313,1616156,20171015,NA
+1992,"Connecticut","CT",9,16,1,"US President","Perot, Ross","independent",FALSE,348771,1616156,20171015,NA
+1992,"Connecticut","CT",9,16,1,"US President","Marrou, Andre","libertarian",FALSE,5391,1616156,20171015,NA
+1992,"Connecticut","CT",9,16,1,"US President","Fulani, Lenora","new alliance",FALSE,1363,1616156,20171015,NA
+1992,"Delaware","DE",10,51,11,"US President","Clinton, Bill","democrat",FALSE,126054,289620,20171015,NA
+1992,"Delaware","DE",10,51,11,"US President","Bush, George H.W.","republican",FALSE,102313,289620,20171015,NA
+1992,"Delaware","DE",10,51,11,"US President","Perot, Ross","independent",FALSE,59213,289620,20171015,NA
+1992,"Delaware","DE",10,51,11,"US President","Fulani, Lenora","new alliance",FALSE,1105,289620,20171015,NA
+1992,"Delaware","DE",10,51,11,"US President","Marrou, Andre","libertarian",FALSE,935,289620,20171015,NA
+1992,"District of Columbia","DC",11,53,55,"US President","Clinton, Bill","democrat",FALSE,192619,227572,20171015,NA
+1992,"District of Columbia","DC",11,53,55,"US President","Bush, George H.W.","republican",FALSE,20698,227572,20171015,NA
+1992,"District of Columbia","DC",11,53,55,"US President","Perot, Ross","independent",FALSE,9681,227572,20171015,NA
+1992,"District of Columbia","DC",11,53,55,"US President","Fulani, Lenora","new alliance",FALSE,1459,227572,20171015,NA
+1992,"District of Columbia","DC",11,53,55,"US President","Daniels, Ronald","independent",FALSE,1446,227572,20171015,NA
+1992,"District of Columbia","DC",11,53,55,"US President","","",TRUE,676,227572,20171015,NA
+1992,"District of Columbia","DC",11,53,55,"US President","Marrou, Andre","libertarian",FALSE,467,227572,20171015,NA
+1992,"District of Columbia","DC",11,53,55,"US President","Hagelin, John","natural law",FALSE,230,227572,20171015,NA
+1992,"District of Columbia","DC",11,53,55,"US President","Other","socialist",FALSE,191,227572,20171015,NA
+1992,"District of Columbia","DC",11,53,55,"US President","Other","socialist workers",FALSE,105,227572,20171015,NA
+1992,"Florida","FL",12,59,43,"US President","Bush, George H.W.","republican",FALSE,2173310,5313392,20171015,NA
+1992,"Florida","FL",12,59,43,"US President","Clinton, Bill","democrat",FALSE,2071698,5313392,20171015,NA
+1992,"Florida","FL",12,59,43,"US President","Perot, Ross","independent",FALSE,1053067,5313392,20171015,NA
+1992,"Florida","FL",12,59,43,"US President","Marrou, Andre","libertarian",FALSE,15079,5313392,20171015,NA
+1992,"Florida","FL",12,59,43,"US President","","",TRUE,238,5313392,20171015,NA
+1992,"Georgia","GA",13,58,44,"US President","Clinton, Bill","democrat",FALSE,1008966,2321133,20171015,NA
+1992,"Georgia","GA",13,58,44,"US President","Bush, George H.W.","republican",FALSE,995252,2321133,20171015,NA
+1992,"Georgia","GA",13,58,44,"US President","Perot, Ross","independent",FALSE,309657,2321133,20171015,NA
+1992,"Georgia","GA",13,58,44,"US President","Marrou, Andre","libertarian",FALSE,7110,2321133,20171015,NA
+1992,"Georgia","GA",13,58,44,"US President","","",TRUE,148,2321133,20171015,NA
+1992,"Hawaii","HI",15,95,82,"US President","Clinton, Bill","democrat",FALSE,179310,372842,20171015,NA
+1992,"Hawaii","HI",15,95,82,"US President","Bush, George H.W.","republican",FALSE,136822,372842,20171015,NA
+1992,"Hawaii","HI",15,95,82,"US President","Perot, Ross","independent",FALSE,53003,372842,20171015,NA
+1992,"Hawaii","HI",15,95,82,"US President","Gritz, James """"Bo""""","independent",FALSE,1452,372842,20171015,NA
+1992,"Hawaii","HI",15,95,82,"US President","Marrou, Andre","libertarian",FALSE,1119,372842,20171015,NA
+1992,"Hawaii","HI",15,95,82,"US President","Fulani, Lenora","new alliance",FALSE,720,372842,20171015,NA
+1992,"Hawaii","HI",15,95,82,"US President","Hagelin, John","natural law",FALSE,416,372842,20171015,NA
+1992,"Idaho","ID",16,82,63,"US President","Bush, George H.W.","republican",FALSE,202645,482114,20171015,NA
+1992,"Idaho","ID",16,82,63,"US President","Clinton, Bill","democrat",FALSE,137013,482114,20171015,NA
+1992,"Idaho","ID",16,82,63,"US President","Perot, Ross","independent",FALSE,130395,482114,20171015,NA
+1992,"Idaho","ID",16,82,63,"US President","Gritz, James """"Bo""""","independent",FALSE,10894,482114,20171015,NA
+1992,"Idaho","ID",16,82,63,"US President","Marrou, Andre","libertarian",FALSE,1167,482114,20171015,NA
+1992,"Illinois","IL",17,33,21,"US President","Clinton, Bill","democrat",FALSE,2453350,5050157,20171015,NA
+1992,"Illinois","IL",17,33,21,"US President","Bush, George H.W.","republican",FALSE,1734096,5050157,20171015,NA
+1992,"Illinois","IL",17,33,21,"US President","Perot, Ross","independent",FALSE,840515,5050157,20171015,NA
+1992,"Illinois","IL",17,33,21,"US President","Marrou, Andre","libertarian",FALSE,9218,5050157,20171015,NA
+1992,"Illinois","IL",17,33,21,"US President","Fulani, Lenora","new alliance",FALSE,5267,5050157,20171015,NA
+1992,"Illinois","IL",17,33,21,"US President","Gritz, James """"Bo""""","populist",FALSE,3577,5050157,20171015,NA
+1992,"Illinois","IL",17,33,21,"US President","Hagelin, John","natural law",FALSE,2751,5050157,20171015,NA
+1992,"Illinois","IL",17,33,21,"US President","Warren, James """"Mac""""","socialist workers",FALSE,1361,5050157,20171015,NA
+1992,"Illinois","IL",17,33,21,"US President","","",TRUE,22,5050157,20171015,NA
+1992,"Indiana","IN",18,32,22,"US President","Bush, George H.W.","republican",FALSE,989375,2305871,20171015,NA
+1992,"Indiana","IN",18,32,22,"US President","Clinton, Bill","democrat",FALSE,848420,2305871,20171015,NA
+1992,"Indiana","IN",18,32,22,"US President","Perot, Ross","independent",FALSE,455934,2305871,20171015,NA
+1992,"Indiana","IN",18,32,22,"US President","Marrou, Andre","libertarian",FALSE,7936,2305871,20171015,NA
+1992,"Indiana","IN",18,32,22,"US President","Fulani, Lenora","new alliance",FALSE,2583,2305871,20171015,NA
+1992,"Indiana","IN",18,32,22,"US President","","",TRUE,1623,2305871,20171015,NA
+1992,"Iowa","IA",19,42,31,"US President","Clinton, Bill","democrat",FALSE,586353,1354607,20171015,NA
+1992,"Iowa","IA",19,42,31,"US President","Bush, George H.W.","republican",FALSE,504891,1354607,20171015,NA
+1992,"Iowa","IA",19,42,31,"US President","Perot, Ross","independent",FALSE,253468,1354607,20171015,NA
+1992,"Iowa","IA",19,42,31,"US President","Hagelin, John","natural law",FALSE,3079,1354607,20171015,NA
+1992,"Iowa","IA",19,42,31,"US President","Other","",FALSE,1753,1354607,20171015,NA
+1992,"Iowa","IA",19,42,31,"US President","Gritz, James """"Bo""""","america first",FALSE,1177,1354607,20171015,NA
+1992,"Iowa","IA",19,42,31,"US President","Marrou, Andre","libertarian",FALSE,1076,1354607,20171015,NA
+1992,"Iowa","IA",19,42,31,"US President","Blank Vote/Scattering","",FALSE,741,1354607,20171015,NA
+1992,"Iowa","IA",19,42,31,"US President","Herer, Jack","grassroots",FALSE,669,1354607,20171015,NA
+1992,"Iowa","IA",19,42,31,"US President","Phillips, Howard","taxpayers party",FALSE,480,1354607,20171015,NA
+1992,"Iowa","IA",19,42,31,"US President","Warren, James """"Mac""""","socialist workers",FALSE,273,1354607,20171015,NA
+1992,"Iowa","IA",19,42,31,"US President","Larouche, Lyndon, Jr.","independents for economic recovery",FALSE,238,1354607,20171015,NA
+1992,"Iowa","IA",19,42,31,"US President","Other","campaign for a new tomorrow",FALSE,212,1354607,20171015,NA
+1992,"Iowa","IA",19,42,31,"US President","Fulani, Lenora","new alliance",FALSE,197,1354607,20171015,NA
+1992,"Kansas","KS",20,47,32,"US President","Bush, George H.W.","republican",FALSE,449951,1157236,20171015,NA
+1992,"Kansas","KS",20,47,32,"US President","Clinton, Bill","democrat",FALSE,390434,1157236,20171015,NA
+1992,"Kansas","KS",20,47,32,"US President","Perot, Ross","independent",FALSE,312358,1157236,20171015,NA
+1992,"Kansas","KS",20,47,32,"US President","Marrou, Andre","libertarian",FALSE,4314,1157236,20171015,NA
+1992,"Kansas","KS",20,47,32,"US President","","",TRUE,179,1157236,20171015,NA
+1992,"Kentucky","KY",21,61,51,"US President","Clinton, Bill","democrat",FALSE,665104,1492900,20171015,NA
+1992,"Kentucky","KY",21,61,51,"US President","Bush, George H.W.","republican",FALSE,617178,1492900,20171015,NA
+1992,"Kentucky","KY",21,61,51,"US President","Perot, Ross","independent",FALSE,203944,1492900,20171015,NA
+1992,"Kentucky","KY",21,61,51,"US President","Marrou, Andre","libertarian",FALSE,4513,1492900,20171015,NA
+1992,"Kentucky","KY",21,61,51,"US President","Phillips, Howard","taxpayers party",FALSE,989,1492900,20171015,NA
+1992,"Kentucky","KY",21,61,51,"US President","Hagelin, John","natural law",FALSE,695,1492900,20171015,NA
+1992,"Kentucky","KY",21,61,51,"US President","Fulani, Lenora","new alliance",FALSE,430,1492900,20171015,NA
+1992,"Kentucky","KY",21,61,51,"US President","","",TRUE,47,1492900,20171015,NA
+1992,"Louisiana","LA",22,72,45,"US President","Clinton, Bill","democrat",FALSE,815971,1790017,20171015,NA
+1992,"Louisiana","LA",22,72,45,"US President","Bush, George H.W.","republican",FALSE,733386,1790017,20171015,NA
+1992,"Louisiana","LA",22,72,45,"US President","Perot, Ross","independent",FALSE,211478,1790017,20171015,NA
+1992,"Louisiana","LA",22,72,45,"US President","Gritz, James """"Bo""""","america first",FALSE,18545,1790017,20171015,NA
+1992,"Louisiana","LA",22,72,45,"US President","Marrou, Andre","libertarian",FALSE,3155,1790017,20171015,NA
+1992,"Louisiana","LA",22,72,45,"US President","Other","equal justice and opportunity",FALSE,1663,1790017,20171015,NA
+1992,"Louisiana","LA",22,72,45,"US President","Phillips, Howard","taxpayers party",FALSE,1552,1790017,20171015,NA
+1992,"Louisiana","LA",22,72,45,"US President","Fulani, Lenora","more perfect democracy",FALSE,1434,1790017,20171015,NA
+1992,"Louisiana","LA",22,72,45,"US President","Larouche, Lyndon, Jr.","justice, industry, and agriculture",FALSE,1136,1790017,20171015,NA
+1992,"Louisiana","LA",22,72,45,"US President","Hagelin, John","natural law",FALSE,889,1790017,20171015,NA
+1992,"Louisiana","LA",22,72,45,"US President","Yiamouyiannis, John","independent",FALSE,808,1790017,20171015,NA
+1992,"Maine","ME",23,11,2,"US President","Clinton, Bill","democrat",FALSE,263420,679499,20171015,NA
+1992,"Maine","ME",23,11,2,"US President","Perot, Ross","independent",FALSE,206820,679499,20171015,NA
+1992,"Maine","ME",23,11,2,"US President","Bush, George H.W.","republican",FALSE,206504,679499,20171015,NA
+1992,"Maine","ME",23,11,2,"US President","Marrou, Andre","libertarian",FALSE,1681,679499,20171015,NA
+1992,"Maine","ME",23,11,2,"US President","Fulani, Lenora","new alliance",FALSE,519,679499,20171015,NA
+1992,"Maine","ME",23,11,2,"US President","Phillips, Howard","taxpayers party",FALSE,464,679499,20171015,NA
+1992,"Maine","ME",23,11,2,"US President","Other","",FALSE,91,679499,20171015,NA
+1992,"Maryland","MD",24,52,52,"US President","Clinton, Bill","democrat",FALSE,988571,1984580,20171015,NA
+1992,"Maryland","MD",24,52,52,"US President","Bush, George H.W.","republican",FALSE,707094,1984580,20171015,NA
+1992,"Maryland","MD",24,52,52,"US President","Perot, Ross","independent",FALSE,281414,1984580,20171015,NA
+1992,"Maryland","MD",24,52,52,"US President","Marrou, Andre","libertarian",FALSE,4715,1984580,20171015,NA
+1992,"Maryland","MD",24,52,52,"US President","Fulani, Lenora","new alliance",FALSE,2786,1984580,20171015,NA
+1992,"Massachusetts","MA",25,14,3,"US President","Clinton, Bill","democrat",FALSE,1318639,2773664,20171015,NA
+1992,"Massachusetts","MA",25,14,3,"US President","Bush, George H.W.","republican",FALSE,805039,2773664,20171015,NA
+1992,"Massachusetts","MA",25,14,3,"US President","Perot, Ross","independent",FALSE,630731,2773664,20171015,NA
+1992,"Massachusetts","MA",25,14,3,"US President","Marrou, Andre","libertarian",FALSE,9021,2773664,20171015,NA
+1992,"Massachusetts","MA",25,14,3,"US President","Fulani, Lenora","new alliance",FALSE,3172,2773664,20171015,NA
+1992,"Massachusetts","MA",25,14,3,"US President","Other","independent voters",FALSE,2218,2773664,20171015,NA
+1992,"Massachusetts","MA",25,14,3,"US President","Other","",FALSE,1990,2773664,20171015,NA
+1992,"Massachusetts","MA",25,14,3,"US President","Hagelin, John","natural law",FALSE,1812,2773664,20171015,NA
+1992,"Massachusetts","MA",25,14,3,"US President","Larouche, Lyndon, Jr.","larouche for president party",FALSE,1027,2773664,20171015,NA
+1992,"Massachusetts","MA",25,14,3,"US President","Brisben, J. Quinn","socialist party usa",FALSE,13,2773664,20171015,NA
+1992,"Massachusetts","MA",25,14,3,"US President","Dodge, Earl","prohibition",FALSE,2,2773664,20171015,NA
+1992,"Michigan","MI",26,34,23,"US President","Clinton, Bill","democrat",FALSE,1871182,4274673,20171015,NA
+1992,"Michigan","MI",26,34,23,"US President","Bush, George H.W.","republican",FALSE,1554940,4274673,20171015,NA
+1992,"Michigan","MI",26,34,23,"US President","Perot, Ross","independent",FALSE,824813,4274673,20171015,NA
+1992,"Michigan","MI",26,34,23,"US President","Marrou, Andre","libertarian",FALSE,10175,4274673,20171015,NA
+1992,"Michigan","MI",26,34,23,"US President","Phillips, Howard","tisch independent citizens",FALSE,8263,4274673,20171015,NA
+1992,"Michigan","MI",26,34,23,"US President","Hagelin, John","natural law",FALSE,2954,4274673,20171015,NA
+1992,"Michigan","MI",26,34,23,"US President","Halyard, Helen","workers world",FALSE,1432,4274673,20171015,NA
+1992,"Michigan","MI",26,34,23,"US President","","",TRUE,914,4274673,20171015,NA
+1992,"Minnesota","MN",27,41,33,"US President","Clinton, Bill","democrat",FALSE,1020997,2347948,20171015,NA
+1992,"Minnesota","MN",27,41,33,"US President","Bush, George H.W.","republican",FALSE,747841,2347948,20171015,NA
+1992,"Minnesota","MN",27,41,33,"US President","Perot, Ross","independent",FALSE,562506,2347948,20171015,NA
+1992,"Minnesota","MN",27,41,33,"US President","Marrou, Andre","libertarian",FALSE,3374,2347948,20171015,NA
+1992,"Minnesota","MN",27,41,33,"US President","Gritz, James """"Bo""""","constitution party",FALSE,3363,2347948,20171015,NA
+1992,"Minnesota","MN",27,41,33,"US President","Herer, Jack","grassroots",FALSE,2659,2347948,20171015,NA
+1992,"Minnesota","MN",27,41,33,"US President","","",TRUE,2499,2347948,20171015,NA
+1992,"Minnesota","MN",27,41,33,"US President","Hagelin, John","natural law",FALSE,1406,2347948,20171015,NA
+1992,"Minnesota","MN",27,41,33,"US President","Warren, James """"Mac""""","socialist workers",FALSE,990,2347948,20171015,NA
+1992,"Minnesota","MN",27,41,33,"US President","Fulani, Lenora","new alliance",FALSE,958,2347948,20171015,NA
+1992,"Minnesota","MN",27,41,33,"US President","Phillips, Howard","taxpayers party",FALSE,733,2347948,20171015,NA
+1992,"Minnesota","MN",27,41,33,"US President","Larouche, Lyndon, Jr.","independents for economic recovery",FALSE,622,2347948,20171015,NA
+1992,"Mississippi","MS",28,64,46,"US President","Bush, George H.W.","republican",FALSE,487793,981793,20171015,NA
+1992,"Mississippi","MS",28,64,46,"US President","Clinton, Bill","democrat",FALSE,400258,981793,20171015,NA
+1992,"Mississippi","MS",28,64,46,"US President","Perot, Ross","independent",FALSE,85626,981793,20171015,NA
+1992,"Mississippi","MS",28,64,46,"US President","Other","independent",FALSE,4310,981793,20171015,NA
+1992,"Mississippi","MS",28,64,46,"US President","Marrou, Andre","libertarian",FALSE,2154,981793,20171015,NA
+1992,"Mississippi","MS",28,64,46,"US President","Phillips, Howard","taxpayers party",FALSE,1652,981793,20171015,NA
+1992,"Missouri","MO",29,43,34,"US President","Clinton, Bill","democrat",FALSE,1053873,2391270,20171015,NA
+1992,"Missouri","MO",29,43,34,"US President","Bush, George H.W.","republican",FALSE,811159,2391270,20171015,NA
+1992,"Missouri","MO",29,43,34,"US President","Perot, Ross","independent",FALSE,518741,2391270,20171015,NA
+1992,"Missouri","MO",29,43,34,"US President","Marrou, Andre","libertarian",FALSE,7497,2391270,20171015,NA
+1992,"Montana","MT",30,81,64,"US President","Clinton, Bill","democrat",FALSE,154507,410583,20171015,NA
+1992,"Montana","MT",30,81,64,"US President","Bush, George H.W.","republican",FALSE,144207,410583,20171015,NA
+1992,"Montana","MT",30,81,64,"US President","Perot, Ross","independent",FALSE,107225,410583,20171015,NA
+1992,"Montana","MT",30,81,64,"US President","Other","independent",FALSE,3658,410583,20171015,NA
+1992,"Montana","MT",30,81,64,"US President","Marrou, Andre","libertarian",FALSE,986,410583,20171015,NA
+1992,"Nebraska","NE",31,46,35,"US President","Bush, George H.W.","republican",FALSE,343678,737546,20171015,NA
+1992,"Nebraska","NE",31,46,35,"US President","Clinton, Bill","democrat",FALSE,216864,737546,20171015,NA
+1992,"Nebraska","NE",31,46,35,"US President","Perot, Ross","independent",FALSE,174104,737546,20171015,NA
+1992,"Nebraska","NE",31,46,35,"US President","Other","independent",FALSE,1560,737546,20171015,NA
+1992,"Nebraska","NE",31,46,35,"US President","Marrou, Andre","libertarian",FALSE,1340,737546,20171015,NA
+1992,"Nevada","NV",32,88,65,"US President","Clinton, Bill","democrat",FALSE,189148,506318,20171015,NA
+1992,"Nevada","NV",32,88,65,"US President","Bush, George H.W.","republican",FALSE,175828,506318,20171015,NA
+1992,"Nevada","NV",32,88,65,"US President","Perot, Ross","independent",FALSE,132580,506318,20171015,NA
+1992,"Nevada","NV",32,88,65,"US President","Gritz, James """"Bo""""","populist",FALSE,2892,506318,20171015,NA
+1992,"Nevada","NV",32,88,65,"US President","Other","",FALSE,2537,506318,20171015,NA
+1992,"Nevada","NV",32,88,65,"US President","Marrou, Andre","libertarian",FALSE,1835,506318,20171015,NA
+1992,"Nevada","NV",32,88,65,"US President","Phillips, Howard","independent american",FALSE,677,506318,20171015,NA
+1992,"Nevada","NV",32,88,65,"US President","Fulani, Lenora","independent",FALSE,483,506318,20171015,NA
+1992,"Nevada","NV",32,88,65,"US President","Hagelin, John","natural law",FALSE,338,506318,20171015,NA
+1992,"New Hampshire","NH",33,12,4,"US President","Clinton, Bill","democrat",FALSE,209040,537215,20171015,NA
+1992,"New Hampshire","NH",33,12,4,"US President","Bush, George H.W.","republican",FALSE,202484,537215,20171015,NA
+1992,"New Hampshire","NH",33,12,4,"US President","Perot, Ross","independent",FALSE,121337,537215,20171015,NA
+1992,"New Hampshire","NH",33,12,4,"US President","Marrou, Andre","libertarian",FALSE,3548,537215,20171015,NA
+1992,"New Hampshire","NH",33,12,4,"US President","Fulani, Lenora","new alliance",FALSE,512,537215,20171015,NA
+1992,"New Hampshire","NH",33,12,4,"US President","Hagelin, John","natural law",FALSE,294,537215,20171015,NA
+1992,"New Jersey","NJ",34,22,12,"US President","Clinton, Bill","democrat",FALSE,1436206,3343594,20171015,NA
+1992,"New Jersey","NJ",34,22,12,"US President","Bush, George H.W.","republican",FALSE,1356865,3343594,20171015,NA
+1992,"New Jersey","NJ",34,22,12,"US President","Perot, Ross","independent",FALSE,521829,3343594,20171015,NA
+1992,"New Jersey","NJ",34,22,12,"US President","Marrou, Andre","libertarian",FALSE,6822,3343594,20171015,NA
+1992,"New Jersey","NJ",34,22,12,"US President","Bradford, Drew","independent",FALSE,4749,3343594,20171015,NA
+1992,"New Jersey","NJ",34,22,12,"US President","Fulani, Lenora","new alliance",FALSE,3513,3343594,20171015,NA
+1992,"New Jersey","NJ",34,22,12,"US President","Phillips, Howard","taxpayers party",FALSE,2670,3343594,20171015,NA
+1992,"New Jersey","NJ",34,22,12,"US President","Larouche, Lyndon, Jr.","6 million jobs",FALSE,2095,3343594,20171015,NA
+1992,"New Jersey","NJ",34,22,12,"US President","Warren, James """"Mac""""","socialist workers",FALSE,2011,3343594,20171015,NA
+1992,"New Jersey","NJ",34,22,12,"US President","Daniels, Ron","ron daniels independent",FALSE,1996,3343594,20171015,NA
+1992,"New Jersey","NJ",34,22,12,"US President","Gritz, James """"Bo""""","america first populist",FALSE,1867,3343594,20171015,NA
+1992,"New Jersey","NJ",34,22,12,"US President","Haylard, Helen","workers league",FALSE,1618,3343594,20171015,NA
+1992,"New Jersey","NJ",34,22,12,"US President","Hagelin, John","natural law",FALSE,1353,3343594,20171015,NA
+1992,"New Mexico","NM",35,85,66,"US President","Clinton, Bill","democrat",FALSE,261617,569986,20171015,NA
+1992,"New Mexico","NM",35,85,66,"US President","Bush, George H.W.","republican",FALSE,212824,569986,20171015,NA
+1992,"New Mexico","NM",35,85,66,"US President","Perot, Ross","independent",FALSE,91895,569986,20171015,NA
+1992,"New Mexico","NM",35,85,66,"US President","Marrou, Andre","libertarian",FALSE,1615,569986,20171015,NA
+1992,"New Mexico","NM",35,85,66,"US President","Phillips, Howard","taxpayers party",FALSE,620,569986,20171015,NA
+1992,"New Mexico","NM",35,85,66,"US President","Hagelin, John","natural law",FALSE,562,569986,20171015,NA
+1992,"New Mexico","NM",35,85,66,"US President","Fulani, Lenora","new alliance",FALSE,369,569986,20171015,NA
+1992,"New Mexico","NM",35,85,66,"US President","Warren, James """"Mac""""","socialist workers",FALSE,183,569986,20171015,NA
+1992,"New Mexico","NM",35,85,66,"US President","La Riva, Gloria Estella","workers world",FALSE,181,569986,20171015,NA
+1992,"New Mexico","NM",35,85,66,"US President","Dodge, Earl","prohibition",FALSE,120,569986,20171015,NA
+1992,"New York","NY",36,21,13,"US President","Clinton, Bill","democrat",FALSE,3346894,7079432,20171015,NA
+1992,"New York","NY",36,21,13,"US President","Bush, George H.W.","republican",FALSE,2041690,7079432,20171015,NA
+1992,"New York","NY",36,21,13,"US President","Perot, Ross","independent",FALSE,1090721,7079432,20171015,NA
+1992,"New York","NY",36,21,13,"US President","Bush, George H.W.","conservative",FALSE,177000,7079432,20171015,NA
+1992,"New York","NY",36,21,13,"US President","Blank Vote/Scattering","",FALSE,152951,7079432,20171015,NA
+1992,"New York","NY",36,21,13,"US President","Bush, George H.W.","right-to-life",FALSE,127959,7079432,20171015,NA
+1992,"New York","NY",36,21,13,"US President","Clinton, Bill","liberal party",FALSE,97556,7079432,20171015,NA
+1992,"New York","NY",36,21,13,"US President","Warren, James """"Mac""""","socialist workers",FALSE,15472,7079432,20171015,NA
+1992,"New York","NY",36,21,13,"US President","Marrou, Andre","libertarian",FALSE,13451,7079432,20171015,NA
+1992,"New York","NY",36,21,13,"US President","Fulani, Lenora","new alliance",FALSE,11318,7079432,20171015,NA
+1992,"New York","NY",36,21,13,"US President","Hagelin, John","natural law",FALSE,4420,7079432,20171015,NA
+1992,"North Carolina","NC",37,56,47,"US President","Bush, George H.W.","republican",FALSE,1134661,2611850,20171015,NA
+1992,"North Carolina","NC",37,56,47,"US President","Clinton, Bill","democrat",FALSE,1114042,2611850,20171015,NA
+1992,"North Carolina","NC",37,56,47,"US President","Perot, Ross","independent",FALSE,357864,2611850,20171015,NA
+1992,"North Carolina","NC",37,56,47,"US President","Marrou, Andre","libertarian",FALSE,5171,2611850,20171015,NA
+1992,"North Carolina","NC",37,56,47,"US President","Fulani, Lenora","new alliance",FALSE,59,2611850,20171015,NA
+1992,"North Carolina","NC",37,56,47,"US President","Hagelin, John","natural law",FALSE,41,2611850,20171015,NA
+1992,"North Carolina","NC",37,56,47,"US President","Warren, James """"Mac""""","socialist workers",FALSE,12,2611850,20171015,NA
+1992,"North Dakota","ND",38,44,36,"US President","Bush, George H.W.","republican",FALSE,136244,308133,20171015,NA
+1992,"North Dakota","ND",38,44,36,"US President","Clinton, Bill","democrat",FALSE,99168,308133,20171015,NA
+1992,"North Dakota","ND",38,44,36,"US President","Perot, Ross","independent",FALSE,71084,308133,20171015,NA
+1992,"North Dakota","ND",38,44,36,"US President","Other","",FALSE,1637,308133,20171015,NA
+1992,"Ohio","OH",39,31,24,"US President","Clinton, Bill","democrat",FALSE,1984942,4939967,20171015,NA
+1992,"Ohio","OH",39,31,24,"US President","Bush, George H.W.","republican",FALSE,1894310,4939967,20171015,NA
+1992,"Ohio","OH",39,31,24,"US President","Perot, Ross","independent",FALSE,1036426,4939967,20171015,NA
+1992,"Ohio","OH",39,31,24,"US President","Other","independent",FALSE,24247,4939967,20171015,NA
+1992,"Ohio","OH",39,31,24,"US President","","",TRUE,42,4939967,20171015,NA
+1992,"Oklahoma","OK",40,73,53,"US President","Bush, George H.W.","republican",FALSE,592929,1390359,20171015,NA
+1992,"Oklahoma","OK",40,73,53,"US President","Clinton, Bill","democrat",FALSE,473066,1390359,20171015,NA
+1992,"Oklahoma","OK",40,73,53,"US President","Perot, Ross","independent",FALSE,319878,1390359,20171015,NA
+1992,"Oklahoma","OK",40,73,53,"US President","Marrou, Andre","libertarian",FALSE,4486,1390359,20171015,NA
+1992,"Oregon","OR",41,92,72,"US President","Clinton, Bill","democrat",FALSE,621314,1462643,20171015,NA
+1992,"Oregon","OR",41,92,72,"US President","Bush, George H.W.","republican",FALSE,475757,1462643,20171015,NA
+1992,"Oregon","OR",41,92,72,"US President","Perot, Ross","independent",FALSE,354091,1462643,20171015,NA
+1992,"Oregon","OR",41,92,72,"US President","Marrou, Andre","libertarian",FALSE,4277,1462643,20171015,NA
+1992,"Oregon","OR",41,92,72,"US President","Fulani, Lenora","new alliance",FALSE,3030,1462643,20171015,NA
+1992,"Oregon","OR",41,92,72,"US President","Other","",FALSE,2609,1462643,20171015,NA
+1992,"Oregon","OR",41,92,72,"US President","","",TRUE,1565,1462643,20171015,NA
+1992,"Pennsylvania","PA",42,23,14,"US President","Clinton, Bill","democrat",FALSE,2239164,4959810,20171015,NA
+1992,"Pennsylvania","PA",42,23,14,"US President","Bush, George H.W.","republican",FALSE,1791841,4959810,20171015,NA
+1992,"Pennsylvania","PA",42,23,14,"US President","Perot, Ross","independent",FALSE,902667,4959810,20171015,NA
+1992,"Pennsylvania","PA",42,23,14,"US President","Marrou, Andre","libertarian",FALSE,21477,4959810,20171015,NA
+1992,"Pennsylvania","PA",42,23,14,"US President","Fulani, Lenora","new alliance",FALSE,4661,4959810,20171015,NA
+1992,"Rhode Island","RI",44,15,5,"US President","Clinton, Bill","democrat",FALSE,213299,453365,20171015,NA
+1992,"Rhode Island","RI",44,15,5,"US President","Bush, George H.W.","republican",FALSE,131601,453365,20171015,NA
+1992,"Rhode Island","RI",44,15,5,"US President","Perot, Ross","independent",FALSE,105045,453365,20171015,NA
+1992,"Rhode Island","RI",44,15,5,"US President","Fulani, Lenora","new alliance",FALSE,1878,453365,20171015,NA
+1992,"Rhode Island","RI",44,15,5,"US President","Marrou, Andre","libertarian",FALSE,571,453365,20171015,NA
+1992,"Rhode Island","RI",44,15,5,"US President","Larouche, Lyndon, Jr.","independents for larouche",FALSE,494,453365,20171015,NA
+1992,"Rhode Island","RI",44,15,5,"US President","Hagelin, John","natural law",FALSE,262,453365,20171015,NA
+1992,"Rhode Island","RI",44,15,5,"US President","Phillips, Howard","taxpayers party",FALSE,215,453365,20171015,NA
+1992,"South Carolina","SC",45,57,48,"US President","Bush, George H.W.","republican",FALSE,577507,1228912,20171015,NA
+1992,"South Carolina","SC",45,57,48,"US President","Clinton, Bill","democrat",FALSE,525514,1228912,20171015,NA
+1992,"South Carolina","SC",45,57,48,"US President","Perot, Ross","independent",FALSE,119257,1228912,20171015,NA
+1992,"South Carolina","SC",45,57,48,"US President","Marrou, Andre","libertarian",FALSE,2719,1228912,20171015,NA
+1992,"South Carolina","SC",45,57,48,"US President","Phillips, Howard","american",FALSE,2680,1228912,20171015,NA
+1992,"South Carolina","SC",45,57,48,"US President","Fulani, Lenora","united citizens",FALSE,1235,1228912,20171015,NA
+1992,"South Dakota","SD",46,45,37,"US President","Bush, George H.W.","republican",FALSE,136718,336254,20171015,NA
+1992,"South Dakota","SD",46,45,37,"US President","Clinton, Bill","democrat",FALSE,124888,336254,20171015,NA
+1992,"South Dakota","SD",46,45,37,"US President","Perot, Ross","independent",FALSE,73295,336254,20171015,NA
+1992,"South Dakota","SD",46,45,37,"US President","Marrou, Andre","libertarian",FALSE,814,336254,20171015,NA
+1992,"South Dakota","SD",46,45,37,"US President","Other","independent",FALSE,539,336254,20171015,NA
+1992,"Tennessee","TN",47,62,54,"US President","Clinton, Bill","democrat",FALSE,933521,1982638,20171015,NA
+1992,"Tennessee","TN",47,62,54,"US President","Bush, George H.W.","republican",FALSE,841300,1982638,20171015,NA
+1992,"Tennessee","TN",47,62,54,"US President","Perot, Ross","independent",FALSE,199968,1982638,20171015,NA
+1992,"Tennessee","TN",47,62,54,"US President","Other","independent",FALSE,7688,1982638,20171015,NA
+1992,"Tennessee","TN",47,62,54,"US President","","",TRUE,161,1982638,20171015,NA
+1992,"Texas","TX",48,74,49,"US President","Bush, George H.W.","republican",FALSE,2496071,6154018,20171015,NA
+1992,"Texas","TX",48,74,49,"US President","Clinton, Bill","democrat",FALSE,2281815,6154018,20171015,NA
+1992,"Texas","TX",48,74,49,"US President","Perot, Ross","independent",FALSE,1354781,6154018,20171015,NA
+1992,"Texas","TX",48,74,49,"US President","Marrou, Andre","libertarian",FALSE,19699,6154018,20171015,NA
+1992,"Texas","TX",48,74,49,"US President","","",TRUE,1652,6154018,20171015,NA
+1992,"Utah","UT",49,87,67,"US President","Bush, George H.W.","republican",FALSE,322632,743998,20171015,NA
+1992,"Utah","UT",49,87,67,"US President","Perot, Ross","independent",FALSE,203400,743998,20171015,NA
+1992,"Utah","UT",49,87,67,"US President","Clinton, Bill","democrat",FALSE,183429,743998,20171015,NA
+1992,"Utah","UT",49,87,67,"US President","Gritz, James """"Bo""""","populist",FALSE,28602,743998,20171015,NA
+1992,"Utah","UT",49,87,67,"US President","Marrou, Andre","libertarian",FALSE,1900,743998,20171015,NA
+1992,"Utah","UT",49,87,67,"US President","Hagelin, John","natural law",FALSE,1319,743998,20171015,NA
+1992,"Utah","UT",49,87,67,"US President","Larouche, Lyndon, Jr.","independents for economic recovery",FALSE,1089,743998,20171015,NA
+1992,"Utah","UT",49,87,67,"US President","Fulani, Lenora","new alliance",FALSE,414,743998,20171015,NA
+1992,"Utah","UT",49,87,67,"US President","Phillips, Howard","taxpayers party",FALSE,393,743998,20171015,NA
+1992,"Utah","UT",49,87,67,"US President","Other","american",FALSE,292,743998,20171015,NA
+1992,"Utah","UT",49,87,67,"US President","Warren, James """"Mac""""","socialist workers",FALSE,200,743998,20171015,NA
+1992,"Utah","UT",49,87,67,"US President","Daniels, Ron","campaign for a new tomorrow",FALSE,177,743998,20171015,NA
+1992,"Utah","UT",49,87,67,"US President","Brisben, J. Quinn","socialist workers",FALSE,151,743998,20171015,NA
+1992,"Vermont","VT",50,13,6,"US President","Clinton, Bill","democrat",FALSE,133592,289701,20171015,NA
+1992,"Vermont","VT",50,13,6,"US President","Bush, George H.W.","republican",FALSE,88122,289701,20171015,NA
+1992,"Vermont","VT",50,13,6,"US President","Perot, Ross","independent",FALSE,65991,289701,20171015,NA
+1992,"Vermont","VT",50,13,6,"US President","Marrou, Andre","libertarian",FALSE,501,289701,20171015,NA
+1992,"Vermont","VT",50,13,6,"US President","","",TRUE,488,289701,20171015,NA
+1992,"Vermont","VT",50,13,6,"US President","Other","liberty union party",FALSE,329,289701,20171015,NA
+1992,"Vermont","VT",50,13,6,"US President","Hagelin, John","natural law",FALSE,315,289701,20171015,NA
+1992,"Vermont","VT",50,13,6,"US President","Phillips, Howard","taxpayers party",FALSE,124,289701,20171015,NA
+1992,"Vermont","VT",50,13,6,"US President","Fulani, Lenora","new alliance",FALSE,100,289701,20171015,NA
+1992,"Vermont","VT",50,13,6,"US President","Warren, James """"Mac""""","socialist workers",FALSE,82,289701,20171015,NA
+1992,"Vermont","VT",50,13,6,"US President","Larouche, Lyndon, Jr.","freedom for larouche",FALSE,57,289701,20171015,NA
+1992,"Virginia","VA",51,54,40,"US President","Bush, George H.W.","republican",FALSE,1150517,2559129,20171015,NA
+1992,"Virginia","VA",51,54,40,"US President","Clinton, Bill","democrat",FALSE,1038650,2559129,20171015,NA
+1992,"Virginia","VA",51,54,40,"US President","Perot, Ross","independent",FALSE,348639,2559129,20171015,NA
+1992,"Virginia","VA",51,54,40,"US President","Other","independent",FALSE,15129,2559129,20171015,NA
+1992,"Virginia","VA",51,54,40,"US President","Marrou, Andre","libertarian",FALSE,5730,2559129,20171015,NA
+1992,"Virginia","VA",51,54,40,"US President","","",TRUE,464,2559129,20171015,NA
+1992,"Washington","WA",53,91,73,"US President","Clinton, Bill","democrat",FALSE,993037,2287565,20171015,NA
+1992,"Washington","WA",53,91,73,"US President","Bush, George H.W.","republican",FALSE,731234,2287565,20171015,NA
+1992,"Washington","WA",53,91,73,"US President","Perot, Ross","independent",FALSE,541780,2287565,20171015,NA
+1992,"Washington","WA",53,91,73,"US President","Marrou, Andre","libertarian",FALSE,7533,2287565,20171015,NA
+1992,"Washington","WA",53,91,73,"US President","Gritz, James """"Bo""""","populist",FALSE,4854,2287565,20171015,NA
+1992,"Washington","WA",53,91,73,"US President","Hagelin, John","natural law",FALSE,2456,2287565,20171015,NA
+1992,"Washington","WA",53,91,73,"US President","Phillips, Howard","taxpayers party",FALSE,2354,2287565,20171015,NA
+1992,"Washington","WA",53,91,73,"US President","Other","independent",FALSE,2026,2287565,20171015,NA
+1992,"Washington","WA",53,91,73,"US President","Fulani, Lenora","new alliance",FALSE,1776,2287565,20171015,NA
+1992,"Washington","WA",53,91,73,"US President","Warren, James """"Mac""""","socialist workers",FALSE,515,2287565,20171015,NA
+1992,"West Virginia","WV",54,55,56,"US President","Clinton, Bill","democrat",FALSE,331001,683677,20171015,NA
+1992,"West Virginia","WV",54,55,56,"US President","Bush, George H.W.","republican",FALSE,241974,683677,20171015,NA
+1992,"West Virginia","WV",54,55,56,"US President","Perot, Ross","independent",FALSE,108829,683677,20171015,NA
+1992,"West Virginia","WV",54,55,56,"US President","Marrou, Andre","libertarian",FALSE,1873,683677,20171015,NA
+1992,"Wisconsin","WI",55,35,25,"US President","Clinton, Bill","democrat",FALSE,1041066,2531064,20171015,NA
+1992,"Wisconsin","WI",55,35,25,"US President","Bush, George H.W.","republican",FALSE,930855,2531064,20171015,NA
+1992,"Wisconsin","WI",55,35,25,"US President","Perot, Ross","independent",FALSE,544479,2531064,20171015,NA
+1992,"Wisconsin","WI",55,35,25,"US President","Other","independent",FALSE,7518,2531064,20171015,NA
+1992,"Wisconsin","WI",55,35,25,"US President","Marrou, Andre","libertarian",FALSE,2877,2531064,20171015,NA
+1992,"Wisconsin","WI",55,35,25,"US President","Daniels, Ron","labor-farm-laborista-agrario",FALSE,1833,2531064,20171015,NA
+1992,"Wisconsin","WI",55,35,25,"US President","Hagelin, John","natural law",FALSE,1070,2531064,20171015,NA
+1992,"Wisconsin","WI",55,35,25,"US President","Blank Vote/Scattering","",FALSE,961,2531064,20171015,NA
+1992,"Wisconsin","WI",55,35,25,"US President","Hem, Roland","third party",FALSE,405,2531064,20171015,NA
+1992,"Wyoming","WY",56,83,68,"US President","Bush, George H.W.","republican",FALSE,79347,199884,20171015,NA
+1992,"Wyoming","WY",56,83,68,"US President","Clinton, Bill","democrat",FALSE,68160,199884,20171015,NA
+1992,"Wyoming","WY",56,83,68,"US President","Perot, Ross","independent",FALSE,51263,199884,20171015,NA
+1992,"Wyoming","WY",56,83,68,"US President","Marrou, Andre","libertarian",FALSE,844,199884,20171015,NA
+1992,"Wyoming","WY",56,83,68,"US President","Fulani, Lenora","independent",FALSE,270,199884,20171015,NA
+1996,"Alabama","AL",1,63,41,"US President","Dole, Robert","republican",FALSE,769044,1534349,20171015,NA
+1996,"Alabama","AL",1,63,41,"US President","Clinton, Bill","democrat",FALSE,662165,1534349,20171015,NA
+1996,"Alabama","AL",1,63,41,"US President","","independent",FALSE,95030,1534349,20171015,NA
+1996,"Alabama","AL",1,63,41,"US President","Browne, Harry","libertarian",FALSE,5290,1534349,20171015,NA
+1996,"Alabama","AL",1,63,41,"US President","Hagelin, John","natural law",FALSE,1697,1534349,20171015,NA
+1996,"Alabama","AL",1,63,41,"US President","","",TRUE,1123,1534349,20171015,NA
+1996,"Alaska","AK",2,94,81,"US President","Dole, Robert","republican",FALSE,122746,241620,20171015,NA
+1996,"Alaska","AK",2,94,81,"US President","Clinton, Bill","democrat",FALSE,80380,241620,20171015,NA
+1996,"Alaska","AK",2,94,81,"US President","Perot, Ross","reform party",FALSE,26333,241620,20171015,NA
+1996,"Alaska","AK",2,94,81,"US President","Nader, Ralph","green",FALSE,7597,241620,20171015,NA
+1996,"Alaska","AK",2,94,81,"US President","Browne, Harry","libertarian",FALSE,2276,241620,20171015,NA
+1996,"Alaska","AK",2,94,81,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,925,241620,20171015,NA
+1996,"Alaska","AK",2,94,81,"US President","Hagelin, John","natural law",FALSE,729,241620,20171015,NA
+1996,"Alaska","AK",2,94,81,"US President","","",TRUE,634,241620,20171015,NA
+1996,"Arizona","AZ",4,86,61,"US President","Clinton, Bill","democrat",FALSE,653288,1404405,20171015,NA
+1996,"Arizona","AZ",4,86,61,"US President","Dole, Robert","republican",FALSE,622073,1404405,20171015,NA
+1996,"Arizona","AZ",4,86,61,"US President","Perot, Ross","reform party",FALSE,112072,1404405,20171015,NA
+1996,"Arizona","AZ",4,86,61,"US President","Browne, Harry","libertarian",FALSE,14358,1404405,20171015,NA
+1996,"Arizona","AZ",4,86,61,"US President","","",TRUE,2573,1404405,20171015,NA
+1996,"Arizona","AZ",4,86,61,"US President","Other","",FALSE,41,1404405,20171015,NA
+1996,"Arkansas","AR",5,71,42,"US President","Clinton, Bill","democrat",FALSE,475171,884262,20171015,NA
+1996,"Arkansas","AR",5,71,42,"US President","Dole, Robert","republican",FALSE,325416,884262,20171015,NA
+1996,"Arkansas","AR",5,71,42,"US President","Perot, Ross","reform party",FALSE,69884,884262,20171015,NA
+1996,"Arkansas","AR",5,71,42,"US President","Nader, Ralph","green",FALSE,3649,884262,20171015,NA
+1996,"Arkansas","AR",5,71,42,"US President","Browne, Harry","libertarian",FALSE,3076,884262,20171015,NA
+1996,"Arkansas","AR",5,71,42,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,2065,884262,20171015,NA
+1996,"Arkansas","AR",5,71,42,"US President","Forbes, Ralph","america first",FALSE,932,884262,20171015,NA
+1996,"Arkansas","AR",5,71,42,"US President","Collins, Charles","unaffiliated",FALSE,823,884262,20171015,NA
+1996,"Arkansas","AR",5,71,42,"US President","Masters, Isabell","looking back party",FALSE,749,884262,20171015,NA
+1996,"Arkansas","AR",5,71,42,"US President","Moorehead, Monica","workers world",FALSE,747,884262,20171015,NA
+1996,"Arkansas","AR",5,71,42,"US President","Hagelin, John","natural law",FALSE,729,884262,20171015,NA
+1996,"Arkansas","AR",5,71,42,"US President","Hollis, Mary Cal","socialist",FALSE,538,884262,20171015,NA
+1996,"Arkansas","AR",5,71,42,"US President","Dodge, Earl","prohibition",FALSE,483,884262,20171015,NA
+1996,"California","CA",6,93,71,"US President","Clinton, Bill","democrat",FALSE,5119835,10019469,20171015,NA
+1996,"California","CA",6,93,71,"US President","Dole, Robert","republican",FALSE,3828381,10019469,20171015,NA
+1996,"California","CA",6,93,71,"US President","Perot, Ross","reform party",FALSE,697847,10019469,20171015,NA
+1996,"California","CA",6,93,71,"US President","Nader, Ralph","green",FALSE,237016,10019469,20171015,NA
+1996,"California","CA",6,93,71,"US President","Browne, Harry","libertarian",FALSE,73600,10019469,20171015,NA
+1996,"California","CA",6,93,71,"US President","Feinland, Marsha","peace & freedom",FALSE,25332,10019469,20171015,NA
+1996,"California","CA",6,93,71,"US President","Phillips, Howard","american independent party",FALSE,21202,10019469,20171015,NA
+1996,"California","CA",6,93,71,"US President","Hagelin, John","natural law",FALSE,15403,10019469,20171015,NA
+1996,"California","CA",6,93,71,"US President","","",TRUE,853,10019469,20171015,NA
+1996,"Colorado","CO",8,84,62,"US President","Dole, Robert","republican",FALSE,691848,1510702,20171015,NA
+1996,"Colorado","CO",8,84,62,"US President","Clinton, Bill","democrat",FALSE,671152,1510702,20171015,NA
+1996,"Colorado","CO",8,84,62,"US President","Perot, Ross","reform party",FALSE,99629,1510702,20171015,NA
+1996,"Colorado","CO",8,84,62,"US President","Nader, Ralph","green",FALSE,25070,1510702,20171015,NA
+1996,"Colorado","CO",8,84,62,"US President","Browne, Harry","libertarian",FALSE,12392,1510702,20171015,NA
+1996,"Colorado","CO",8,84,62,"US President","Phillips, Howard","constitution party",FALSE,2813,1510702,20171015,NA
+1996,"Colorado","CO",8,84,62,"US President","Collins, Charles","independent",FALSE,2809,1510702,20171015,NA
+1996,"Colorado","CO",8,84,62,"US President","Hagelin, John","natural law",FALSE,2545,1510702,20171015,NA
+1996,"Colorado","CO",8,84,62,"US President","Hollis, Mary Cal","socialist",FALSE,669,1510702,20171015,NA
+1996,"Colorado","CO",8,84,62,"US President","Moorehead, Monica","workers world",FALSE,599,1510702,20171015,NA
+1996,"Colorado","CO",8,84,62,"US President","Templin, Diane","american",FALSE,557,1510702,20171015,NA
+1996,"Colorado","CO",8,84,62,"US President","Dodge, Earl","prohibition",FALSE,375,1510702,20171015,NA
+1996,"Colorado","CO",8,84,62,"US President","Harris, James","socialist workers",FALSE,244,1510702,20171015,NA
+1996,"Connecticut","CT",9,16,1,"US President","Clinton, Bill","democrat",FALSE,735740,1392614,20171015,NA
+1996,"Connecticut","CT",9,16,1,"US President","Dole, Robert","republican",FALSE,483109,1392614,20171015,NA
+1996,"Connecticut","CT",9,16,1,"US President","Perot, Ross","reform party",FALSE,139523,1392614,20171015,NA
+1996,"Connecticut","CT",9,16,1,"US President","Nader, Ralph","green",FALSE,24321,1392614,20171015,NA
+1996,"Connecticut","CT",9,16,1,"US President","Browne, Harry","libertarian",FALSE,5788,1392614,20171015,NA
+1996,"Connecticut","CT",9,16,1,"US President","Phillips, Howard","concerned citizens",FALSE,2425,1392614,20171015,NA
+1996,"Connecticut","CT",9,16,1,"US President","Hagelin, John","natural law",FALSE,1703,1392614,20171015,NA
+1996,"Connecticut","CT",9,16,1,"US President","","",TRUE,5,1392614,20171015,NA
+1996,"Delaware","DE",10,51,11,"US President","Clinton, Bill","democrat",FALSE,140355,270810,20171015,NA
+1996,"Delaware","DE",10,51,11,"US President","Dole, Robert","republican",FALSE,99062,270810,20171015,NA
+1996,"Delaware","DE",10,51,11,"US President","Perot, Ross","unaffiliated",FALSE,28719,270810,20171015,NA
+1996,"Delaware","DE",10,51,11,"US President","Browne, Harry","libertarian",FALSE,2052,270810,20171015,NA
+1996,"Delaware","DE",10,51,11,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,348,270810,20171015,NA
+1996,"Delaware","DE",10,51,11,"US President","Hagelin, John","natural law",FALSE,274,270810,20171015,NA
+1996,"District of Columbia","DC",11,53,55,"US President","Clinton, Bill","democrat",FALSE,158220,185726,20171015,NA
+1996,"District of Columbia","DC",11,53,55,"US President","Dole, Robert","republican",FALSE,17339,185726,20171015,NA
+1996,"District of Columbia","DC",11,53,55,"US President","Nader, Ralph","green",FALSE,4780,185726,20171015,NA
+1996,"District of Columbia","DC",11,53,55,"US President","Perot, Ross","reform party",FALSE,3611,185726,20171015,NA
+1996,"District of Columbia","DC",11,53,55,"US President","","",TRUE,648,185726,20171015,NA
+1996,"District of Columbia","DC",11,53,55,"US President","Browne, Harry","libertarian",FALSE,588,185726,20171015,NA
+1996,"District of Columbia","DC",11,53,55,"US President","Hagelin, John","natural law",FALSE,283,185726,20171015,NA
+1996,"District of Columbia","DC",11,53,55,"US President","Harris, James","socialist workers",FALSE,257,185726,20171015,NA
+1996,"Florida","FL",12,59,43,"US President","Clinton, Bill","democrat",FALSE,2546870,5303154,20171015,NA
+1996,"Florida","FL",12,59,43,"US President","Dole, Robert","republican",FALSE,2244536,5303154,20171015,NA
+1996,"Florida","FL",12,59,43,"US President","Perot, Ross","reform party",FALSE,483870,5303154,20171015,NA
+1996,"Florida","FL",12,59,43,"US President","Browne, Harry","libertarian",FALSE,23326,5303154,20171015,NA
+1996,"Florida","FL",12,59,43,"US President","","",TRUE,4552,5303154,20171015,NA
+1996,"Georgia","GA",13,58,44,"US President","Dole, Robert","republican",FALSE,1080843,2298899,20171015,NA
+1996,"Georgia","GA",13,58,44,"US President","Clinton, Bill","democrat",FALSE,1053849,2298899,20171015,NA
+1996,"Georgia","GA",13,58,44,"US President","Perot, Ross","reform party",FALSE,146337,2298899,20171015,NA
+1996,"Georgia","GA",13,58,44,"US President","Browne, Harry","libertarian",FALSE,17870,2298899,20171015,NA
+1996,"Hawaii","HI",15,95,82,"US President","Clinton, Bill","democrat",FALSE,205012,360120,20171015,NA
+1996,"Hawaii","HI",15,95,82,"US President","Dole, Robert","republican",FALSE,113943,360120,20171015,NA
+1996,"Hawaii","HI",15,95,82,"US President","Perot, Ross","reform party",FALSE,27358,360120,20171015,NA
+1996,"Hawaii","HI",15,95,82,"US President","Nader, Ralph","green",FALSE,10386,360120,20171015,NA
+1996,"Hawaii","HI",15,95,82,"US President","Browne, Harry","libertarian",FALSE,2493,360120,20171015,NA
+1996,"Hawaii","HI",15,95,82,"US President","Hagelin, John","natural law",FALSE,570,360120,20171015,NA
+1996,"Hawaii","HI",15,95,82,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,358,360120,20171015,NA
+1996,"Idaho","ID",16,82,63,"US President","Dole, Robert","republican",FALSE,256595,491711,20171015,NA
+1996,"Idaho","ID",16,82,63,"US President","Clinton, Bill","democrat",FALSE,165443,491711,20171015,NA
+1996,"Idaho","ID",16,82,63,"US President","Perot, Ross","reform party",FALSE,62518,491711,20171015,NA
+1996,"Idaho","ID",16,82,63,"US President","Browne, Harry","libertarian",FALSE,3325,491711,20171015,NA
+1996,"Idaho","ID",16,82,63,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,2230,491711,20171015,NA
+1996,"Idaho","ID",16,82,63,"US President","Hagelin, John","natural law",FALSE,1600,491711,20171015,NA
+1996,"Illinois","IL",17,33,21,"US President","Clinton, Bill","democrat",FALSE,2341744,4311391,20171015,NA
+1996,"Illinois","IL",17,33,21,"US President","Dole, Robert","republican",FALSE,1587021,4311391,20171015,NA
+1996,"Illinois","IL",17,33,21,"US President","Perot, Ross","reform party",FALSE,346408,4311391,20171015,NA
+1996,"Illinois","IL",17,33,21,"US President","Browne, Harry","libertarian",FALSE,22548,4311391,20171015,NA
+1996,"Illinois","IL",17,33,21,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,7606,4311391,20171015,NA
+1996,"Illinois","IL",17,33,21,"US President","Hagelin, John","natural law",FALSE,4606,4311391,20171015,NA
+1996,"Illinois","IL",17,33,21,"US President","","",TRUE,1458,4311391,20171015,NA
+1996,"Indiana","IN",18,32,22,"US President","Dole, Robert","republican",FALSE,1006693,2135431,20171015,NA
+1996,"Indiana","IN",18,32,22,"US President","Clinton, Bill","democrat",FALSE,887424,2135431,20171015,NA
+1996,"Indiana","IN",18,32,22,"US President","Perot, Ross","reform party",FALSE,224299,2135431,20171015,NA
+1996,"Indiana","IN",18,32,22,"US President","Browne, Harry","libertarian",FALSE,15632,2135431,20171015,NA
+1996,"Indiana","IN",18,32,22,"US President","","",TRUE,1383,2135431,20171015,NA
+1996,"Iowa","IA",19,42,31,"US President","Clinton, Bill","democrat",FALSE,620258,1234075,20171015,NA
+1996,"Iowa","IA",19,42,31,"US President","Dole, Robert","republican",FALSE,492644,1234075,20171015,NA
+1996,"Iowa","IA",19,42,31,"US President","Perot, Ross","reform party",FALSE,105159,1234075,20171015,NA
+1996,"Iowa","IA",19,42,31,"US President","Nader, Ralph","green",FALSE,6550,1234075,20171015,NA
+1996,"Iowa","IA",19,42,31,"US President","Hagelin, John","natural law",FALSE,3349,1234075,20171015,NA
+1996,"Iowa","IA",19,42,31,"US President","Browne, Harry","libertarian",FALSE,2315,1234075,20171015,NA
+1996,"Iowa","IA",19,42,31,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,2229,1234075,20171015,NA
+1996,"Iowa","IA",19,42,31,"US President","Scattering","",FALSE,1240,1234075,20171015,NA
+1996,"Iowa","IA",19,42,31,"US President","Harris, James","socialist workers",FALSE,331,1234075,20171015,NA
+1996,"Kansas","KS",20,47,32,"US President","Dole, Robert","republican",FALSE,583245,1074300,20171015,NA
+1996,"Kansas","KS",20,47,32,"US President","Clinton, Bill","democrat",FALSE,387659,1074300,20171015,NA
+1996,"Kansas","KS",20,47,32,"US President","Perot, Ross","reform party",FALSE,92639,1074300,20171015,NA
+1996,"Kansas","KS",20,47,32,"US President","","independent",FALSE,5174,1074300,20171015,NA
+1996,"Kansas","KS",20,47,32,"US President","Browne, Harry","libertarian",FALSE,4557,1074300,20171015,NA
+1996,"Kansas","KS",20,47,32,"US President","","",TRUE,1026,1074300,20171015,NA
+1996,"Kentucky","KY",21,61,51,"US President","Clinton, Bill","democrat",FALSE,636614,1388708,20171015,NA
+1996,"Kentucky","KY",21,61,51,"US President","Dole, Robert","republican",FALSE,623283,1388708,20171015,NA
+1996,"Kentucky","KY",21,61,51,"US President","Perot, Ross","reform party",FALSE,120396,1388708,20171015,NA
+1996,"Kentucky","KY",21,61,51,"US President","Browne, Harry","libertarian",FALSE,4009,1388708,20171015,NA
+1996,"Kentucky","KY",21,61,51,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,2204,1388708,20171015,NA
+1996,"Kentucky","KY",21,61,51,"US President","Hagelin, John","natural law",FALSE,1493,1388708,20171015,NA
+1996,"Kentucky","KY",21,61,51,"US President","","",TRUE,709,1388708,20171015,NA
+1996,"Louisiana","LA",22,72,45,"US President","Clinton, Bill","democrat",FALSE,927837,1783959,20171015,NA
+1996,"Louisiana","LA",22,72,45,"US President","Dole, Robert","republican",FALSE,712586,1783959,20171015,NA
+1996,"Louisiana","LA",22,72,45,"US President","Perot, Ross","reform party",FALSE,123293,1783959,20171015,NA
+1996,"Louisiana","LA",22,72,45,"US President","Browne, Harry","libertarian",FALSE,7499,1783959,20171015,NA
+1996,"Louisiana","LA",22,72,45,"US President","Nader, Ralph","liberty, ecology, community",FALSE,4719,1783959,20171015,NA
+1996,"Louisiana","LA",22,72,45,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,3366,1783959,20171015,NA
+1996,"Louisiana","LA",22,72,45,"US President","Hagelin, John","natural law",FALSE,2981,1783959,20171015,NA
+1996,"Louisiana","LA",22,72,45,"US President","Moorehead, Monica","workers world",FALSE,1678,1783959,20171015,NA
+1996,"Maine","ME",23,11,2,"US President","Clinton, Bill","democrat",FALSE,312788,605897,20171015,NA
+1996,"Maine","ME",23,11,2,"US President","Dole, Robert","republican",FALSE,186378,605897,20171015,NA
+1996,"Maine","ME",23,11,2,"US President","Perot, Ross","reform party",FALSE,85970,605897,20171015,NA
+1996,"Maine","ME",23,11,2,"US President","Nader, Ralph","green",FALSE,15279,605897,20171015,NA
+1996,"Maine","ME",23,11,2,"US President","Browne, Harry","libertarian",FALSE,2996,605897,20171015,NA
+1996,"Maine","ME",23,11,2,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,1517,605897,20171015,NA
+1996,"Maine","ME",23,11,2,"US President","Hagelin, John","natural law",FALSE,825,605897,20171015,NA
+1996,"Maine","ME",23,11,2,"US President","Other","",FALSE,144,605897,20171015,NA
+1996,"Maryland","MD",24,52,52,"US President","Clinton, Bill","democrat",FALSE,966207,1780870,20171015,NA
+1996,"Maryland","MD",24,52,52,"US President","Dole, Robert","republican",FALSE,681530,1780870,20171015,NA
+1996,"Maryland","MD",24,52,52,"US President","Perot, Ross","reform party",FALSE,115812,1780870,20171015,NA
+1996,"Maryland","MD",24,52,52,"US President","Browne, Harry","libertarian",FALSE,8765,1780870,20171015,NA
+1996,"Maryland","MD",24,52,52,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,3402,1780870,20171015,NA
+1996,"Maryland","MD",24,52,52,"US President","","",TRUE,2637,1780870,20171015,NA
+1996,"Maryland","MD",24,52,52,"US President","Hagelin, John","natural law",FALSE,2517,1780870,20171015,NA
+1996,"Massachusetts","MA",25,14,3,"US President","Clinton, Bill","democrat",FALSE,1571509,2556459,20171015,NA
+1996,"Massachusetts","MA",25,14,3,"US President","Dole, Robert","republican",FALSE,718058,2556459,20171015,NA
+1996,"Massachusetts","MA",25,14,3,"US President","Perot, Ross","reform party",FALSE,227206,2556459,20171015,NA
+1996,"Massachusetts","MA",25,14,3,"US President","Browne, Harry","libertarian",FALSE,20424,2556459,20171015,NA
+1996,"Massachusetts","MA",25,14,3,"US President","Other","",FALSE,6180,2556459,20171015,NA
+1996,"Massachusetts","MA",25,14,3,"US President","Hagelin, John","natural law",FALSE,5183,2556459,20171015,NA
+1996,"Massachusetts","MA",25,14,3,"US President","","",TRUE,4623,2556459,20171015,NA
+1996,"Massachusetts","MA",25,14,3,"US President","Moorehead, Monica","workers world",FALSE,3276,2556459,20171015,NA
+1996,"Michigan","MI",26,34,23,"US President","Clinton, Bill","democrat",FALSE,1989653,3848844,20171015,NA
+1996,"Michigan","MI",26,34,23,"US President","Dole, Robert","republican",FALSE,1481212,3848844,20171015,NA
+1996,"Michigan","MI",26,34,23,"US President","Perot, Ross","reform party",FALSE,336670,3848844,20171015,NA
+1996,"Michigan","MI",26,34,23,"US President","Browne, Harry","libertarian",FALSE,27670,3848844,20171015,NA
+1996,"Michigan","MI",26,34,23,"US President","","",TRUE,4678,3848844,20171015,NA
+1996,"Michigan","MI",26,34,23,"US President","Hagelin, John","natural law",FALSE,4254,3848844,20171015,NA
+1996,"Michigan","MI",26,34,23,"US President","Moorehead, Monica","workers world",FALSE,3153,3848844,20171015,NA
+1996,"Michigan","MI",26,34,23,"US President","White, Jerome """"Jerry""""","socialist equality party",FALSE,1554,3848844,20171015,NA
+1996,"Minnesota","MN",27,41,33,"US President","Clinton, Bill","democrat",FALSE,1120380,2192492,20171015,NA
+1996,"Minnesota","MN",27,41,33,"US President","Dole, Robert","republican",FALSE,766395,2192492,20171015,NA
+1996,"Minnesota","MN",27,41,33,"US President","Perot, Ross","reform party",FALSE,257698,2192492,20171015,NA
+1996,"Minnesota","MN",27,41,33,"US President","Nader, Ralph","green",FALSE,24906,2192492,20171015,NA
+1996,"Minnesota","MN",27,41,33,"US President","Browne, Harry","libertarian",FALSE,8271,2192492,20171015,NA
+1996,"Minnesota","MN",27,41,33,"US President","Peron, Dennis","grassroots",FALSE,4898,2192492,20171015,NA
+1996,"Minnesota","MN",27,41,33,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,3415,2192492,20171015,NA
+1996,"Minnesota","MN",27,41,33,"US President","","",TRUE,2903,2192492,20171015,NA
+1996,"Minnesota","MN",27,41,33,"US President","Hagelin, John","natural law",FALSE,1808,2192492,20171015,NA
+1996,"Minnesota","MN",27,41,33,"US President","Birrenback, John","independent grassroots",FALSE,787,2192492,20171015,NA
+1996,"Minnesota","MN",27,41,33,"US President","Harris, James","socialist workers",FALSE,684,2192492,20171015,NA
+1996,"Minnesota","MN",27,41,33,"US President","White, Jerome """"Jerry""""","socialist equality party",FALSE,347,2192492,20171015,NA
+1996,"Mississippi","MS",28,64,46,"US President","Dole, Robert","republican",FALSE,439838,893857,20171015,NA
+1996,"Mississippi","MS",28,64,46,"US President","Clinton, Bill","democrat",FALSE,394022,893857,20171015,NA
+1996,"Mississippi","MS",28,64,46,"US President","","independent",FALSE,53427,893857,20171015,NA
+1996,"Mississippi","MS",28,64,46,"US President","Browne, Harry","libertarian",FALSE,2809,893857,20171015,NA
+1996,"Mississippi","MS",28,64,46,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,2314,893857,20171015,NA
+1996,"Mississippi","MS",28,64,46,"US President","Hagelin, John","natural law",FALSE,1447,893857,20171015,NA
+1996,"Missouri","MO",29,43,34,"US President","Clinton, Bill","democrat",FALSE,1025935,2158065,20171015,NA
+1996,"Missouri","MO",29,43,34,"US President","Dole, Robert","republican",FALSE,890016,2158065,20171015,NA
+1996,"Missouri","MO",29,43,34,"US President","Perot, Ross","reform party",FALSE,217188,2158065,20171015,NA
+1996,"Missouri","MO",29,43,34,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,11521,2158065,20171015,NA
+1996,"Missouri","MO",29,43,34,"US President","Browne, Harry","libertarian",FALSE,10522,2158065,20171015,NA
+1996,"Missouri","MO",29,43,34,"US President","Hagelin, John","natural law",FALSE,2287,2158065,20171015,NA
+1996,"Missouri","MO",29,43,34,"US President","","independent",FALSE,596,2158065,20171015,NA
+1996,"Montana","MT",30,81,64,"US President","Dole, Robert","republican",FALSE,179652,407083,20171015,NA
+1996,"Montana","MT",30,81,64,"US President","Clinton, Bill","democrat",FALSE,167922,407083,20171015,NA
+1996,"Montana","MT",30,81,64,"US President","Perot, Ross","reform party",FALSE,55229,407083,20171015,NA
+1996,"Montana","MT",30,81,64,"US President","Browne, Harry","libertarian",FALSE,2526,407083,20171015,NA
+1996,"Montana","MT",30,81,64,"US President","Hagelin, John","natural law",FALSE,1754,407083,20171015,NA
+1996,"Nebraska","NE",31,46,35,"US President","Dole, Robert","republican",FALSE,363467,677415,20171015,NA
+1996,"Nebraska","NE",31,46,35,"US President","Clinton, Bill","democrat",FALSE,236761,677415,20171015,NA
+1996,"Nebraska","NE",31,46,35,"US President","Perot, Ross","reform party",FALSE,71278,677415,20171015,NA
+1996,"Nebraska","NE",31,46,35,"US President","Browne, Harry","libertarian",FALSE,2792,677415,20171015,NA
+1996,"Nebraska","NE",31,46,35,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,1928,677415,20171015,NA
+1996,"Nebraska","NE",31,46,35,"US President","Hagelin, John","natural law",FALSE,1189,677415,20171015,NA
+1996,"Nevada","NV",32,88,65,"US President","Clinton, Bill","democrat",FALSE,203974,464279,20171015,NA
+1996,"Nevada","NV",32,88,65,"US President","Dole, Robert","republican",FALSE,199244,464279,20171015,NA
+1996,"Nevada","NV",32,88,65,"US President","Perot, Ross","reform party",FALSE,43986,464279,20171015,NA
+1996,"Nevada","NV",32,88,65,"US President","None Of The Above","",FALSE,5608,464279,20171015,NA
+1996,"Nevada","NV",32,88,65,"US President","Nader, Ralph","green",FALSE,4730,464279,20171015,NA
+1996,"Nevada","NV",32,88,65,"US President","Browne, Harry","libertarian",FALSE,4460,464279,20171015,NA
+1996,"Nevada","NV",32,88,65,"US President","Phillips, Howard","independent american",FALSE,1732,464279,20171015,NA
+1996,"Nevada","NV",32,88,65,"US President","Hagelin, John","natural law",FALSE,545,464279,20171015,NA
+1996,"New Hampshire","NH",33,12,4,"US President","Clinton, Bill","democrat",FALSE,246166,496597,20171015,NA
+1996,"New Hampshire","NH",33,12,4,"US President","Dole, Robert","republican",FALSE,196486,496597,20171015,NA
+1996,"New Hampshire","NH",33,12,4,"US President","Perot, Ross","reform party",FALSE,48387,496597,20171015,NA
+1996,"New Hampshire","NH",33,12,4,"US President","Browne, Harry","libertarian",FALSE,4214,496597,20171015,NA
+1996,"New Hampshire","NH",33,12,4,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,1344,496597,20171015,NA
+1996,"New Jersey","NJ",34,22,12,"US President","Clinton, Bill","democrat",FALSE,1652361,3075860,20171015,NA
+1996,"New Jersey","NJ",34,22,12,"US President","Dole, Robert","republican",FALSE,1103099,3075860,20171015,NA
+1996,"New Jersey","NJ",34,22,12,"US President","","independent",FALSE,320400,3075860,20171015,NA
+1996,"New Mexico","NM",35,85,66,"US President","Clinton, Bill","democrat",FALSE,273495,556074,20171015,NA
+1996,"New Mexico","NM",35,85,66,"US President","Dole, Robert","republican",FALSE,232751,556074,20171015,NA
+1996,"New Mexico","NM",35,85,66,"US President","Perot, Ross","reform party",FALSE,32257,556074,20171015,NA
+1996,"New Mexico","NM",35,85,66,"US President","Nader, Ralph","green",FALSE,13218,556074,20171015,NA
+1996,"New Mexico","NM",35,85,66,"US President","Browne, Harry","libertarian",FALSE,2996,556074,20171015,NA
+1996,"New Mexico","NM",35,85,66,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,713,556074,20171015,NA
+1996,"New Mexico","NM",35,85,66,"US President","Hagelin, John","natural law",FALSE,644,556074,20171015,NA
+1996,"New York","NY",36,21,13,"US President","Clinton, Bill","democrat",FALSE,3649630,6439129,20171015,NA
+1996,"New York","NY",36,21,13,"US President","Dole, Robert","republican",FALSE,1738707,6439129,20171015,NA
+1996,"New York","NY",36,21,13,"US President","Perot, Ross","independence",FALSE,503458,6439129,20171015,NA
+1996,"New York","NY",36,21,13,"US President","Dole, Robert","conservative",FALSE,183392,6439129,20171015,NA
+1996,"New York","NY",36,21,13,"US President","Blank Vote/Scattering","",FALSE,123000,6439129,20171015,NA
+1996,"New York","NY",36,21,13,"US President","Clinton, Bill","liberal party",FALSE,106547,6439129,20171015,NA
+1996,"New York","NY",36,21,13,"US President","Nader, Ralph","green",FALSE,75956,6439129,20171015,NA
+1996,"New York","NY",36,21,13,"US President","Phillips, Howard","right-to-life",FALSE,23580,6439129,20171015,NA
+1996,"New York","NY",36,21,13,"US President","Browne, Harry","libertarian",FALSE,12220,6439129,20171015,NA
+1996,"New York","NY",36,21,13,"US President","Dole, Robert","freedom",FALSE,11393,6439129,20171015,NA
+1996,"New York","NY",36,21,13,"US President","Hagelin, John","natural law",FALSE,5011,6439129,20171015,NA
+1996,"New York","NY",36,21,13,"US President","Moorehead, Monica","workers world",FALSE,3473,6439129,20171015,NA
+1996,"New York","NY",36,21,13,"US President","Harris, James","socialist workers",FALSE,2762,6439129,20171015,NA
+1996,"North Carolina","NC",37,56,47,"US President","Dole, Robert","republican",FALSE,1225938,2515807,20171015,NA
+1996,"North Carolina","NC",37,56,47,"US President","Clinton, Bill","democrat",FALSE,1107849,2515807,20171015,NA
+1996,"North Carolina","NC",37,56,47,"US President","Perot, Ross","reform party",FALSE,168059,2515807,20171015,NA
+1996,"North Carolina","NC",37,56,47,"US President","Browne, Harry","libertarian",FALSE,8740,2515807,20171015,NA
+1996,"North Carolina","NC",37,56,47,"US President","Hagelin, John","natural law",FALSE,2771,2515807,20171015,NA
+1996,"North Carolina","NC",37,56,47,"US President","","",TRUE,2450,2515807,20171015,NA
+1996,"North Dakota","ND",38,44,36,"US President","Dole, Robert","republican",FALSE,125050,266411,20171015,NA
+1996,"North Dakota","ND",38,44,36,"US President","Clinton, Bill","democrat",FALSE,106905,266411,20171015,NA
+1996,"North Dakota","ND",38,44,36,"US President","Perot, Ross","reform party",FALSE,32515,266411,20171015,NA
+1996,"North Dakota","ND",38,44,36,"US President","Browne, Harry","libertarian",FALSE,847,266411,20171015,NA
+1996,"North Dakota","ND",38,44,36,"US President","Phillips, Howard","independent nomination",FALSE,745,266411,20171015,NA
+1996,"North Dakota","ND",38,44,36,"US President","Hagelin, John","natural law",FALSE,349,266411,20171015,NA
+1996,"Ohio","OH",39,31,24,"US President","Clinton, Bill","democrat",FALSE,2148222,4534434,20171015,NA
+1996,"Ohio","OH",39,31,24,"US President","Dole, Robert","republican",FALSE,1859883,4534434,20171015,NA
+1996,"Ohio","OH",39,31,24,"US President","Perot, Ross","reform party",FALSE,483207,4534434,20171015,NA
+1996,"Ohio","OH",39,31,24,"US President","Browne, Harry","libertarian",FALSE,12851,4534434,20171015,NA
+1996,"Ohio","OH",39,31,24,"US President","Moorehead, Monica","workers world",FALSE,10813,4534434,20171015,NA
+1996,"Ohio","OH",39,31,24,"US President","Hagelin, John","natural law",FALSE,9120,4534434,20171015,NA
+1996,"Ohio","OH",39,31,24,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,7361,4534434,20171015,NA
+1996,"Ohio","OH",39,31,24,"US President","Nader, Ralph","green",FALSE,2962,4534434,20171015,NA
+1996,"Ohio","OH",39,31,24,"US President","Other","",FALSE,15,4534434,20171015,NA
+1996,"Oklahoma","OK",40,73,53,"US President","Dole, Robert","republican",FALSE,582315,1206713,20171015,NA
+1996,"Oklahoma","OK",40,73,53,"US President","Clinton, Bill","democrat",FALSE,488105,1206713,20171015,NA
+1996,"Oklahoma","OK",40,73,53,"US President","Perot, Ross","reform party",FALSE,130788,1206713,20171015,NA
+1996,"Oklahoma","OK",40,73,53,"US President","Browne, Harry","libertarian",FALSE,5505,1206713,20171015,NA
+1996,"Oregon","OR",41,92,72,"US President","Clinton, Bill","democrat",FALSE,649641,1377760,20171015,NA
+1996,"Oregon","OR",41,92,72,"US President","Dole, Robert","republican",FALSE,538152,1377760,20171015,NA
+1996,"Oregon","OR",41,92,72,"US President","Perot, Ross","reform party",FALSE,121221,1377760,20171015,NA
+1996,"Oregon","OR",41,92,72,"US President","Nader, Ralph","green",FALSE,49415,1377760,20171015,NA
+1996,"Oregon","OR",41,92,72,"US President","Browne, Harry","libertarian",FALSE,8903,1377760,20171015,NA
+1996,"Oregon","OR",41,92,72,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,3379,1377760,20171015,NA
+1996,"Oregon","OR",41,92,72,"US President","Hagelin, John","natural law",FALSE,2798,1377760,20171015,NA
+1996,"Oregon","OR",41,92,72,"US President","Other","",FALSE,2329,1377760,20171015,NA
+1996,"Oregon","OR",41,92,72,"US President","Hollis, Mary Cal","socialist",FALSE,1922,1377760,20171015,NA
+1996,"Pennsylvania","PA",42,23,14,"US President","Clinton, Bill","democrat",FALSE,2215819,4501307,20171015,NA
+1996,"Pennsylvania","PA",42,23,14,"US President","Dole, Robert","republican",FALSE,1801169,4501307,20171015,NA
+1996,"Pennsylvania","PA",42,23,14,"US President","Perot, Ross","reform party",FALSE,430984,4501307,20171015,NA
+1996,"Pennsylvania","PA",42,23,14,"US President","Browne, Harry","libertarian",FALSE,28000,4501307,20171015,NA
+1996,"Pennsylvania","PA",42,23,14,"US President","Phillips, Howard","constitution party",FALSE,19552,4501307,20171015,NA
+1996,"Pennsylvania","PA",42,23,14,"US President","Hagelin, John","natural law",FALSE,5783,4501307,20171015,NA
+1996,"Rhode Island","RI",44,15,5,"US President","Clinton, Bill","democrat",FALSE,233050,390247,20171015,NA
+1996,"Rhode Island","RI",44,15,5,"US President","Dole, Robert","republican",FALSE,104683,390247,20171015,NA
+1996,"Rhode Island","RI",44,15,5,"US President","Perot, Ross","reform party",FALSE,43723,390247,20171015,NA
+1996,"Rhode Island","RI",44,15,5,"US President","Nader, Ralph","green",FALSE,6040,390247,20171015,NA
+1996,"Rhode Island","RI",44,15,5,"US President","Browne, Harry","libertarian",FALSE,1109,390247,20171015,NA
+1996,"Rhode Island","RI",44,15,5,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,1021,390247,20171015,NA
+1996,"Rhode Island","RI",44,15,5,"US President","Hagelin, John","natural law",FALSE,435,390247,20171015,NA
+1996,"Rhode Island","RI",44,15,5,"US President","Moorehead, Monica","workers world",FALSE,186,390247,20171015,NA
+1996,"South Carolina","SC",45,57,48,"US President","Dole, Robert","republican",FALSE,573339,1150182,20171015,NA
+1996,"South Carolina","SC",45,57,48,"US President","Clinton, Bill","democrat",FALSE,506152,1150182,20171015,NA
+1996,"South Carolina","SC",45,57,48,"US President","Perot, Ross","patriot party",FALSE,36913,1150182,20171015,NA
+1996,"South Carolina","SC",45,57,48,"US President","Perot, Ross","reform party",FALSE,27464,1150182,20171015,NA
+1996,"South Carolina","SC",45,57,48,"US President","Browne, Harry","libertarian",FALSE,4271,1150182,20171015,NA
+1996,"South Carolina","SC",45,57,48,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,2043,1150182,20171015,NA
+1996,"South Dakota","SD",46,45,37,"US President","Dole, Robert","republican",FALSE,150543,323826,20171015,NA
+1996,"South Dakota","SD",46,45,37,"US President","Clinton, Bill","democrat",FALSE,139333,323826,20171015,NA
+1996,"South Dakota","SD",46,45,37,"US President","","independent",FALSE,32478,323826,20171015,NA
+1996,"South Dakota","SD",46,45,37,"US President","Browne, Harry","libertarian",FALSE,1472,323826,20171015,NA
+1996,"Tennessee","TN",47,62,54,"US President","Clinton, Bill","democrat",FALSE,909146,1894105,20171015,NA
+1996,"Tennessee","TN",47,62,54,"US President","Dole, Robert","republican",FALSE,863530,1894105,20171015,NA
+1996,"Tennessee","TN",47,62,54,"US President","","independent",FALSE,121239,1894105,20171015,NA
+1996,"Tennessee","TN",47,62,54,"US President","","",TRUE,190,1894105,20171015,NA
+1996,"Texas","TX",48,74,49,"US President","Dole, Robert","republican",FALSE,2736167,5611644,20171015,NA
+1996,"Texas","TX",48,74,49,"US President","Clinton, Bill","democrat",FALSE,2459683,5611644,20171015,NA
+1996,"Texas","TX",48,74,49,"US President","Perot, Ross","independent",FALSE,378537,5611644,20171015,NA
+1996,"Texas","TX",48,74,49,"US President","Browne, Harry","libertarian",FALSE,20256,5611644,20171015,NA
+1996,"Texas","TX",48,74,49,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,7472,5611644,20171015,NA
+1996,"Texas","TX",48,74,49,"US President","","",TRUE,5107,5611644,20171015,NA
+1996,"Texas","TX",48,74,49,"US President","Hagelin, John","natural law",FALSE,4422,5611644,20171015,NA
+1996,"Utah","UT",49,87,67,"US President","Dole, Robert","republican",FALSE,361911,665629,20171015,NA
+1996,"Utah","UT",49,87,67,"US President","Clinton, Bill","democrat",FALSE,221633,665629,20171015,NA
+1996,"Utah","UT",49,87,67,"US President","Perot, Ross","reform party",FALSE,66461,665629,20171015,NA
+1996,"Utah","UT",49,87,67,"US President","Nader, Ralph","green",FALSE,4615,665629,20171015,NA
+1996,"Utah","UT",49,87,67,"US President","Browne, Harry","libertarian",FALSE,4129,665629,20171015,NA
+1996,"Utah","UT",49,87,67,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,2601,665629,20171015,NA
+1996,"Utah","UT",49,87,67,"US President","Templin, Diane","independent american",FALSE,1290,665629,20171015,NA
+1996,"Utah","UT",49,87,67,"US President","Crane, Peter","independent",FALSE,1101,665629,20171015,NA
+1996,"Utah","UT",49,87,67,"US President","Hagelin, John","natural law",FALSE,1085,665629,20171015,NA
+1996,"Utah","UT",49,87,67,"US President","Moorehead, Monica","workers world",FALSE,298,665629,20171015,NA
+1996,"Utah","UT",49,87,67,"US President","Harris, James","socialist workers",FALSE,235,665629,20171015,NA
+1996,"Utah","UT",49,87,67,"US President","","",TRUE,159,665629,20171015,NA
+1996,"Utah","UT",49,87,67,"US President","Dodge, Earl","prohibition",FALSE,111,665629,20171015,NA
+1996,"Vermont","VT",50,13,6,"US President","Clinton, Bill","democrat",FALSE,137894,258449,20171015,NA
+1996,"Vermont","VT",50,13,6,"US President","Dole, Robert","republican",FALSE,80352,258449,20171015,NA
+1996,"Vermont","VT",50,13,6,"US President","Perot, Ross","reform party",FALSE,31024,258449,20171015,NA
+1996,"Vermont","VT",50,13,6,"US President","Nader, Ralph","green",FALSE,5585,258449,20171015,NA
+1996,"Vermont","VT",50,13,6,"US President","Browne, Harry","libertarian",FALSE,1183,258449,20171015,NA
+1996,"Vermont","VT",50,13,6,"US President","","",TRUE,560,258449,20171015,NA
+1996,"Vermont","VT",50,13,6,"US President","Hagelin, John","natural law",FALSE,498,258449,20171015,NA
+1996,"Vermont","VT",50,13,6,"US President","Peron, Dennis","grassroots",FALSE,480,258449,20171015,NA
+1996,"Vermont","VT",50,13,6,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,382,258449,20171015,NA
+1996,"Vermont","VT",50,13,6,"US President","Hollis, Mary Cal","liberty union party",FALSE,292,258449,20171015,NA
+1996,"Vermont","VT",50,13,6,"US President","Harris, James","socialist workers",FALSE,199,258449,20171015,NA
+1996,"Virginia","VA",51,54,40,"US President","Dole, Robert","republican",FALSE,1138350,2416642,20171015,NA
+1996,"Virginia","VA",51,54,40,"US President","Clinton, Bill","democrat",FALSE,1091060,2416642,20171015,NA
+1996,"Virginia","VA",51,54,40,"US President","Perot, Ross","reform party",FALSE,159861,2416642,20171015,NA
+1996,"Virginia","VA",51,54,40,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,13687,2416642,20171015,NA
+1996,"Virginia","VA",51,54,40,"US President","Browne, Harry","libertarian",FALSE,9174,2416642,20171015,NA
+1996,"Virginia","VA",51,54,40,"US President","Hagelin, John","natural law",FALSE,4510,2416642,20171015,NA
+1996,"Washington","WA",53,91,73,"US President","Clinton, Bill","democrat",FALSE,1123323,2253837,20171015,NA
+1996,"Washington","WA",53,91,73,"US President","Dole, Robert","republican",FALSE,840712,2253837,20171015,NA
+1996,"Washington","WA",53,91,73,"US President","Perot, Ross","reform party",FALSE,201003,2253837,20171015,NA
+1996,"Washington","WA",53,91,73,"US President","","independent",FALSE,62696,2253837,20171015,NA
+1996,"Washington","WA",53,91,73,"US President","Browne, Harry","libertarian",FALSE,12522,2253837,20171015,NA
+1996,"Washington","WA",53,91,73,"US President","Hagelin, John","natural law",FALSE,6076,2253837,20171015,NA
+1996,"Washington","WA",53,91,73,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,4578,2253837,20171015,NA
+1996,"Washington","WA",53,91,73,"US President","Moorehead, Monica","workers world",FALSE,2189,2253837,20171015,NA
+1996,"Washington","WA",53,91,73,"US President","Harris, James","socialist workers",FALSE,738,2253837,20171015,NA
+1996,"West Virginia","WV",54,55,56,"US President","Clinton, Bill","democrat",FALSE,327812,636459,20171015,NA
+1996,"West Virginia","WV",54,55,56,"US President","Dole, Robert","republican",FALSE,233946,636459,20171015,NA
+1996,"West Virginia","WV",54,55,56,"US President","Perot, Ross","reform party",FALSE,71639,636459,20171015,NA
+1996,"West Virginia","WV",54,55,56,"US President","Browne, Harry","libertarian",FALSE,3062,636459,20171015,NA
+1996,"Wisconsin","WI",55,35,25,"US President","Clinton, Bill","democrat",FALSE,1071971,2196169,20171015,NA
+1996,"Wisconsin","WI",55,35,25,"US President","Dole, Robert","republican",FALSE,845029,2196169,20171015,NA
+1996,"Wisconsin","WI",55,35,25,"US President","Perot, Ross","reform party",FALSE,227339,2196169,20171015,NA
+1996,"Wisconsin","WI",55,35,25,"US President","","independent",FALSE,32766,2196169,20171015,NA
+1996,"Wisconsin","WI",55,35,25,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,8811,2196169,20171015,NA
+1996,"Wisconsin","WI",55,35,25,"US President","Browne, Harry","libertarian",FALSE,7929,2196169,20171015,NA
+1996,"Wisconsin","WI",55,35,25,"US President","Scattering","",FALSE,2324,2196169,20171015,NA
+1996,"Wyoming","WY",56,83,68,"US President","Dole, Robert","republican",FALSE,105388,211571,20171015,NA
+1996,"Wyoming","WY",56,83,68,"US President","Clinton, Bill","democrat",FALSE,77934,211571,20171015,NA
+1996,"Wyoming","WY",56,83,68,"US President","Perot, Ross","independent",FALSE,25928,211571,20171015,NA
+1996,"Wyoming","WY",56,83,68,"US President","Browne, Harry","libertarian",FALSE,1739,211571,20171015,NA
+1996,"Wyoming","WY",56,83,68,"US President","Hagelin, John","natural law",FALSE,582,211571,20171015,NA
+2000,"Alabama","AL",1,63,41,"US President","Bush, George W.","republican",FALSE,941173,1666272,20171015,NA
+2000,"Alabama","AL",1,63,41,"US President","Gore, Al","democrat",FALSE,692611,1666272,20171015,NA
+2000,"Alabama","AL",1,63,41,"US President","","independent",FALSE,25896,1666272,20171015,NA
+2000,"Alabama","AL",1,63,41,"US President","Browne, Harry","libertarian",FALSE,5893,1666272,20171015,NA
+2000,"Alabama","AL",1,63,41,"US President","","",TRUE,699,1666272,20171015,NA
+2000,"Alaska","AK",2,94,81,"US President","Bush, George W.","republican",FALSE,167398,285560,20171015,NA
+2000,"Alaska","AK",2,94,81,"US President","Gore, Al","democrat",FALSE,79004,285560,20171015,NA
+2000,"Alaska","AK",2,94,81,"US President","Nader, Ralph","green",FALSE,28747,285560,20171015,NA
+2000,"Alaska","AK",2,94,81,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,5192,285560,20171015,NA
+2000,"Alaska","AK",2,94,81,"US President","Browne, Harry","libertarian",FALSE,2636,285560,20171015,NA
+2000,"Alaska","AK",2,94,81,"US President","","",TRUE,1068,285560,20171015,NA
+2000,"Alaska","AK",2,94,81,"US President","Hagelin, John","natural law",FALSE,919,285560,20171015,NA
+2000,"Alaska","AK",2,94,81,"US President","Phillips, Howard","constitution party",FALSE,596,285560,20171015,NA
+2000,"Arizona","AZ",4,86,61,"US President","Bush, George W.","republican",FALSE,781652,1532016,20171015,NA
+2000,"Arizona","AZ",4,86,61,"US President","Gore, Al","democrat",FALSE,685341,1532016,20171015,NA
+2000,"Arizona","AZ",4,86,61,"US President","Nader, Ralph","green",FALSE,45645,1532016,20171015,NA
+2000,"Arizona","AZ",4,86,61,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,12373,1532016,20171015,NA
+2000,"Arizona","AZ",4,86,61,"US President","L. Neil, Smith","libertarian",FALSE,5775,1532016,20171015,NA
+2000,"Arizona","AZ",4,86,61,"US President","Hagelin, John","natural law",FALSE,1120,1532016,20171015,NA
+2000,"Arizona","AZ",4,86,61,"US President","","",TRUE,110,1532016,20171015,NA
+2000,"Arkansas","AR",5,71,42,"US President","Bush, George W.","republican",FALSE,472940,921781,20171015,NA
+2000,"Arkansas","AR",5,71,42,"US President","Gore, Al","democrat",FALSE,422768,921781,20171015,NA
+2000,"Arkansas","AR",5,71,42,"US President","Nader, Ralph","green",FALSE,13421,921781,20171015,NA
+2000,"Arkansas","AR",5,71,42,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,7358,921781,20171015,NA
+2000,"Arkansas","AR",5,71,42,"US President","Browne, Harry","libertarian",FALSE,2781,921781,20171015,NA
+2000,"Arkansas","AR",5,71,42,"US President","Phillips, Howard","constitution party",FALSE,1415,921781,20171015,NA
+2000,"Arkansas","AR",5,71,42,"US President","Hagelin, John","natural law",FALSE,1098,921781,20171015,NA
+2000,"California","CA",6,93,71,"US President","Gore, Al","democrat",FALSE,5861203,10965822,20171015,NA
+2000,"California","CA",6,93,71,"US President","Bush, George W.","republican",FALSE,4567429,10965822,20171015,NA
+2000,"California","CA",6,93,71,"US President","Nader, Ralph","green",FALSE,418707,10965822,20171015,NA
+2000,"California","CA",6,93,71,"US President","Browne, Harry","libertarian",FALSE,45520,10965822,20171015,NA
+2000,"California","CA",6,93,71,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,44987,10965822,20171015,NA
+2000,"California","CA",6,93,71,"US President","Phillips, Howard","american independent party",FALSE,17042,10965822,20171015,NA
+2000,"California","CA",6,93,71,"US President","Hagelin, John","natural law",FALSE,10934,10965822,20171015,NA
+2000,"Colorado","CO",8,84,62,"US President","Bush, George W.","republican",FALSE,883748,1741368,20171015,NA
+2000,"Colorado","CO",8,84,62,"US President","Gore, Al","democrat",FALSE,738227,1741368,20171015,NA
+2000,"Colorado","CO",8,84,62,"US President","Nader, Ralph","green",FALSE,91434,1741368,20171015,NA
+2000,"Colorado","CO",8,84,62,"US President","Browne, Harry","libertarian",FALSE,12799,1741368,20171015,NA
+2000,"Colorado","CO",8,84,62,"US President","Hagelin, John","freedom",FALSE,10465,1741368,20171015,NA
+2000,"Colorado","CO",8,84,62,"US President","Hagelin, John","natural law",FALSE,2240,1741368,20171015,NA
+2000,"Colorado","CO",8,84,62,"US President","Phillips, Howard","constitution party",FALSE,1319,1741368,20171015,NA
+2000,"Colorado","CO",8,84,62,"US President","McReynolds, David","socialist",FALSE,712,1741368,20171015,NA
+2000,"Colorado","CO",8,84,62,"US President","Harris, James","socialist workers",FALSE,216,1741368,20171015,NA
+2000,"Colorado","CO",8,84,62,"US President","Dodge, Earl","prohibition",FALSE,208,1741368,20171015,NA
+2000,"Connecticut","CT",9,16,1,"US President","Gore, Al","democrat",FALSE,816015,1459525,20171015,NA
+2000,"Connecticut","CT",9,16,1,"US President","Bush, George W.","republican",FALSE,561094,1459525,20171015,NA
+2000,"Connecticut","CT",9,16,1,"US President","Nader, Ralph","green",FALSE,64452,1459525,20171015,NA
+2000,"Connecticut","CT",9,16,1,"US President","Phillips, Howard","concerned citizens",FALSE,9695,1459525,20171015,NA
+2000,"Connecticut","CT",9,16,1,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,4731,1459525,20171015,NA
+2000,"Connecticut","CT",9,16,1,"US President","Browne, Harry","libertarian",FALSE,3484,1459525,20171015,NA
+2000,"Connecticut","CT",9,16,1,"US President","","",TRUE,54,1459525,20171015,NA
+2000,"Delaware","DE",10,51,11,"US President","Gore, Al","democrat",FALSE,180068,327529,20171015,NA
+2000,"Delaware","DE",10,51,11,"US President","Bush, George W.","republican",FALSE,137288,327529,20171015,NA
+2000,"Delaware","DE",10,51,11,"US President","Nader, Ralph","green",FALSE,8307,327529,20171015,NA
+2000,"Delaware","DE",10,51,11,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,777,327529,20171015,NA
+2000,"Delaware","DE",10,51,11,"US President","Browne, Harry","libertarian",FALSE,774,327529,20171015,NA
+2000,"Delaware","DE",10,51,11,"US President","Phillips, Howard","constitution party",FALSE,208,327529,20171015,NA
+2000,"Delaware","DE",10,51,11,"US President","Hagelin, John","natural law",FALSE,107,327529,20171015,NA
+2000,"District of Columbia","DC",11,53,55,"US President","Gore, Al","democrat",FALSE,171923,201894,20171015,NA
+2000,"District of Columbia","DC",11,53,55,"US President","Bush, George W.","republican",FALSE,18073,201894,20171015,NA
+2000,"District of Columbia","DC",11,53,55,"US President","Nader, Ralph","green",FALSE,10576,201894,20171015,NA
+2000,"District of Columbia","DC",11,53,55,"US President","Browne, Harry","libertarian",FALSE,669,201894,20171015,NA
+2000,"District of Columbia","DC",11,53,55,"US President","","",TRUE,539,201894,20171015,NA
+2000,"District of Columbia","DC",11,53,55,"US President","Harris, James","socialist workers",FALSE,114,201894,20171015,NA
+2000,"Florida","FL",12,59,43,"US President","Bush, George W.","republican",FALSE,2912790,5963110,20171015,NA
+2000,"Florida","FL",12,59,43,"US President","Gore, Al","democrat",FALSE,2912253,5963110,20171015,NA
+2000,"Florida","FL",12,59,43,"US President","Nader, Ralph","green",FALSE,97488,5963110,20171015,NA
+2000,"Florida","FL",12,59,43,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,17484,5963110,20171015,NA
+2000,"Florida","FL",12,59,43,"US President","Browne, Harry","libertarian",FALSE,16415,5963110,20171015,NA
+2000,"Florida","FL",12,59,43,"US President","Hagelin, John","natural law",FALSE,2281,5963110,20171015,NA
+2000,"Florida","FL",12,59,43,"US President","Moorehead, Monica","workers world",FALSE,1804,5963110,20171015,NA
+2000,"Florida","FL",12,59,43,"US President","Phillips, Howard","constitution party",FALSE,1371,5963110,20171015,NA
+2000,"Florida","FL",12,59,43,"US President","McReynolds, David","socialist",FALSE,622,5963110,20171015,NA
+2000,"Florida","FL",12,59,43,"US President","Harris, James","socialist workers",FALSE,562,5963110,20171015,NA
+2000,"Florida","FL",12,59,43,"US President","","",TRUE,40,5963110,20171015,NA
+2000,"Georgia","GA",13,58,44,"US President","Bush, George W.","republican",FALSE,1419720,2583208,20171015,NA
+2000,"Georgia","GA",13,58,44,"US President","Gore, Al","democrat",FALSE,1116230,2583208,20171015,NA
+2000,"Georgia","GA",13,58,44,"US President","Browne, Harry","libertarian",FALSE,36332,2583208,20171015,NA
+2000,"Georgia","GA",13,58,44,"US President","Buchanan, Patrick """"Pat""""","independent",FALSE,10926,2583208,20171015,NA
+2000,"Hawaii","HI",15,95,82,"US President","Gore, Al","democrat",FALSE,205286,367951,20171015,NA
+2000,"Hawaii","HI",15,95,82,"US President","Bush, George W.","republican",FALSE,137845,367951,20171015,NA
+2000,"Hawaii","HI",15,95,82,"US President","Nader, Ralph","green",FALSE,21623,367951,20171015,NA
+2000,"Hawaii","HI",15,95,82,"US President","Browne, Harry","libertarian",FALSE,1477,367951,20171015,NA
+2000,"Hawaii","HI",15,95,82,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,1071,367951,20171015,NA
+2000,"Hawaii","HI",15,95,82,"US President","Phillips, Howard","constitution party",FALSE,343,367951,20171015,NA
+2000,"Hawaii","HI",15,95,82,"US President","Hagelin, John","natural law",FALSE,306,367951,20171015,NA
+2000,"Idaho","ID",16,82,63,"US President","Bush, George W.","republican",FALSE,336937,501615,20171015,NA
+2000,"Idaho","ID",16,82,63,"US President","Gore, Al","democrat",FALSE,138637,501615,20171015,NA
+2000,"Idaho","ID",16,82,63,"US President","Nader, Ralph","green",TRUE,12292,501615,20171015,NA
+2000,"Idaho","ID",16,82,63,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,7615,501615,20171015,NA
+2000,"Idaho","ID",16,82,63,"US President","Browne, Harry","libertarian",FALSE,3488,501615,20171015,NA
+2000,"Idaho","ID",16,82,63,"US President","Phillips, Howard","constitution party",FALSE,1469,501615,20171015,NA
+2000,"Idaho","ID",16,82,63,"US President","Hagelin, John","natural law",FALSE,1177,501615,20171015,NA
+2000,"Illinois","IL",17,33,21,"US President","Gore, Al","democrat",FALSE,2589026,4742108,20171015,NA
+2000,"Illinois","IL",17,33,21,"US President","Bush, George W.","republican",FALSE,2019421,4742108,20171015,NA
+2000,"Illinois","IL",17,33,21,"US President","Nader, Ralph","green",FALSE,103759,4742108,20171015,NA
+2000,"Illinois","IL",17,33,21,"US President","","independent",FALSE,16106,4742108,20171015,NA
+2000,"Illinois","IL",17,33,21,"US President","Browne, Harry","libertarian",FALSE,11623,4742108,20171015,NA
+2000,"Illinois","IL",17,33,21,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,2127,4742108,20171015,NA
+2000,"Illinois","IL",17,33,21,"US President","","",TRUE,46,4742108,20171015,NA
+2000,"Indiana","IN",18,32,22,"US President","Bush, George W.","republican",FALSE,1245836,2199302,20171015,NA
+2000,"Indiana","IN",18,32,22,"US President","Gore, Al","democrat",FALSE,901980,2199302,20171015,NA
+2000,"Indiana","IN",18,32,22,"US President","","",TRUE,18997,2199302,20171015,NA
+2000,"Indiana","IN",18,32,22,"US President","Buchanan, Patrick """"Pat""""","independent",FALSE,16959,2199302,20171015,NA
+2000,"Indiana","IN",18,32,22,"US President","Browne, Harry","libertarian",FALSE,15530,2199302,20171015,NA
+2000,"Iowa","IA",19,42,31,"US President","Gore, Al","democrat",FALSE,638517,1353022,20171015,NA
+2000,"Iowa","IA",19,42,31,"US President","Bush, George W.","republican",FALSE,634373,1353022,20171015,NA
+2000,"Iowa","IA",19,42,31,"US President","","independent",FALSE,37459,1353022,20171015,NA
+2000,"Iowa","IA",19,42,31,"US President","Nader, Ralph","green",FALSE,29374,1353022,20171015,NA
+2000,"Iowa","IA",19,42,31,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,5731,1353022,20171015,NA
+2000,"Iowa","IA",19,42,31,"US President","Browne, Harry","libertarian",FALSE,3209,1353022,20171015,NA
+2000,"Iowa","IA",19,42,31,"US President","Hagelin, John","nominated by petition",FALSE,2281,1353022,20171015,NA
+2000,"Iowa","IA",19,42,31,"US President","Scattering","",FALSE,1168,1353022,20171015,NA
+2000,"Iowa","IA",19,42,31,"US President","Phillips, Howard","constitution party",FALSE,613,1353022,20171015,NA
+2000,"Iowa","IA",19,42,31,"US President","Harris, James","socialist workers",FALSE,190,1353022,20171015,NA
+2000,"Iowa","IA",19,42,31,"US President","McReynolds, David","socialist",FALSE,107,1353022,20171015,NA
+2000,"Kansas","KS",20,47,32,"US President","Bush, George W.","republican",FALSE,622332,1072216,20171015,NA
+2000,"Kansas","KS",20,47,32,"US President","Gore, Al","democrat",FALSE,399276,1072216,20171015,NA
+2000,"Kansas","KS",20,47,32,"US President","","independent",FALSE,37459,1072216,20171015,NA
+2000,"Kansas","KS",20,47,32,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,7370,1072216,20171015,NA
+2000,"Kansas","KS",20,47,32,"US President","Browne, Harry","libertarian",FALSE,4525,1072216,20171015,NA
+2000,"Kansas","KS",20,47,32,"US President","Phillips, Howard","constitution party",FALSE,1254,1072216,20171015,NA
+2000,"Kentucky","KY",21,61,51,"US President","Bush, George W.","republican",FALSE,872520,1544106,20171015,NA
+2000,"Kentucky","KY",21,61,51,"US President","Gore, Al","democrat",FALSE,638923,1544106,20171015,NA
+2000,"Kentucky","KY",21,61,51,"US President","Nader, Ralph","green",FALSE,23118,1544106,20171015,NA
+2000,"Kentucky","KY",21,61,51,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,4152,1544106,20171015,NA
+2000,"Kentucky","KY",21,61,51,"US President","Browne, Harry","libertarian",FALSE,2885,1544106,20171015,NA
+2000,"Kentucky","KY",21,61,51,"US President","Hagelin, John","natural law",FALSE,1513,1544106,20171015,NA
+2000,"Kentucky","KY",21,61,51,"US President","","constitution party",FALSE,915,1544106,20171015,NA
+2000,"Kentucky","KY",21,61,51,"US President","","",TRUE,80,1544106,20171015,NA
+2000,"Louisiana","LA",22,72,45,"US President","Bush, George W.","republican",FALSE,927871,1765656,20171015,NA
+2000,"Louisiana","LA",22,72,45,"US President","Gore, Al","democrat",FALSE,792344,1765656,20171015,NA
+2000,"Louisiana","LA",22,72,45,"US President","Nader, Ralph","green",FALSE,20473,1765656,20171015,NA
+2000,"Louisiana","LA",22,72,45,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,14356,1765656,20171015,NA
+2000,"Louisiana","LA",22,72,45,"US President","Phillips, Howard","constitution party",FALSE,5483,1765656,20171015,NA
+2000,"Louisiana","LA",22,72,45,"US President","Browne, Harry","libertarian",FALSE,2951,1765656,20171015,NA
+2000,"Louisiana","LA",22,72,45,"US President","Harris, James","socialist workers",FALSE,1103,1765656,20171015,NA
+2000,"Louisiana","LA",22,72,45,"US President","Hagelin, John","natural law",FALSE,1075,1765656,20171015,NA
+2000,"Maine","ME",23,11,2,"US President","Gore, Al","democrat",FALSE,319951,651817,20171015,NA
+2000,"Maine","ME",23,11,2,"US President","Bush, George W.","republican",FALSE,286616,651817,20171015,NA
+2000,"Maine","ME",23,11,2,"US President","Nader, Ralph","green",FALSE,37127,651817,20171015,NA
+2000,"Maine","ME",23,11,2,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,4443,651817,20171015,NA
+2000,"Maine","ME",23,11,2,"US President","Browne, Harry","libertarian",FALSE,3074,651817,20171015,NA
+2000,"Maine","ME",23,11,2,"US President","Phillips, Howard","constitution party",FALSE,579,651817,20171015,NA
+2000,"Maine","ME",23,11,2,"US President","Other","",FALSE,27,651817,20171015,NA
+2000,"Maryland","MD",24,52,52,"US President","Gore, Al","democrat",FALSE,1144008,2025212,20171015,NA
+2000,"Maryland","MD",24,52,52,"US President","Bush, George W.","republican",FALSE,813827,2025212,20171015,NA
+2000,"Maryland","MD",24,52,52,"US President","Nader, Ralph","green",FALSE,53768,2025212,20171015,NA
+2000,"Maryland","MD",24,52,52,"US President","Browne, Harry","libertarian",FALSE,5310,2025212,20171015,NA
+2000,"Maryland","MD",24,52,52,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,4248,2025212,20171015,NA
+2000,"Maryland","MD",24,52,52,"US President","","",TRUE,1656,2025212,20171015,NA
+2000,"Maryland","MD",24,52,52,"US President","Other","",FALSE,1477,2025212,20171015,NA
+2000,"Maryland","MD",24,52,52,"US President","Phillips, Howard","constitution party",FALSE,918,2025212,20171015,NA
+2000,"Massachusetts","MA",25,14,3,"US President","Gore, Al","democrat",FALSE,1616487,2733964,20171015,NA
+2000,"Massachusetts","MA",25,14,3,"US President","Bush, George W.","republican",FALSE,878502,2733964,20171015,NA
+2000,"Massachusetts","MA",25,14,3,"US President","Nader, Ralph","green",FALSE,173564,2733964,20171015,NA
+2000,"Massachusetts","MA",25,14,3,"US President","Blank Vote/Scattering","",FALSE,31022,2733964,20171015,NA
+2000,"Massachusetts","MA",25,14,3,"US President","Browne, Harry","libertarian",FALSE,16366,2733964,20171015,NA
+2000,"Massachusetts","MA",25,14,3,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,11149,2733964,20171015,NA
+2000,"Massachusetts","MA",25,14,3,"US President","Other","",FALSE,3990,2733964,20171015,NA
+2000,"Massachusetts","MA",25,14,3,"US President","Hagelin, John","unenrolled",FALSE,2884,2733964,20171015,NA
+2000,"Michigan","MI",26,34,23,"US President","Gore, Al","democrat",FALSE,2170418,4232501,20171015,NA
+2000,"Michigan","MI",26,34,23,"US President","Bush, George W.","republican",FALSE,1953139,4232501,20171015,NA
+2000,"Michigan","MI",26,34,23,"US President","Nader, Ralph","green",FALSE,84165,4232501,20171015,NA
+2000,"Michigan","MI",26,34,23,"US President","Browne, Harry","libertarian",FALSE,16711,4232501,20171015,NA
+2000,"Michigan","MI",26,34,23,"US President","Phillips, Howard","u.s. taxpayers party",FALSE,3791,4232501,20171015,NA
+2000,"Michigan","MI",26,34,23,"US President","Hagelin, John","natural law",FALSE,2426,4232501,20171015,NA
+2000,"Michigan","MI",26,34,23,"US President","","",TRUE,1851,4232501,20171015,NA
+2000,"Minnesota","MN",27,41,33,"US President","Gore, Al","democratic-farmer-labor",FALSE,1168266,2438685,20171015,NA
+2000,"Minnesota","MN",27,41,33,"US President","Bush, George W.","republican",FALSE,1109659,2438685,20171015,NA
+2000,"Minnesota","MN",27,41,33,"US President","Nader, Ralph","green",FALSE,126696,2438685,20171015,NA
+2000,"Minnesota","MN",27,41,33,"US President","Buchanan, Patrick """"Pat""""","reform party minnesota",FALSE,22166,2438685,20171015,NA
+2000,"Minnesota","MN",27,41,33,"US President","Browne, Harry","libertarian",FALSE,5282,2438685,20171015,NA
+2000,"Minnesota","MN",27,41,33,"US President","Phillips, Howard","constitution party",FALSE,3272,2438685,20171015,NA
+2000,"Minnesota","MN",27,41,33,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,2294,2438685,20171015,NA
+2000,"Minnesota","MN",27,41,33,"US President","Harris, James","socialist workers",FALSE,1022,2438685,20171015,NA
+2000,"Minnesota","MN",27,41,33,"US President","","",TRUE,28,2438685,20171015,NA
+2000,"Mississippi","MS",28,64,46,"US President","Bush, George W.","republican",FALSE,572844,994184,20171015,NA
+2000,"Mississippi","MS",28,64,46,"US President","Gore, Al","democrat",FALSE,404614,994184,20171015,NA
+2000,"Mississippi","MS",28,64,46,"US President","","independent",FALSE,8735,994184,20171015,NA
+2000,"Mississippi","MS",28,64,46,"US President","Phillips, Howard","constitution party",FALSE,3267,994184,20171015,NA
+2000,"Mississippi","MS",28,64,46,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,2265,994184,20171015,NA
+2000,"Mississippi","MS",28,64,46,"US President","Browne, Harry","libertarian",FALSE,2009,994184,20171015,NA
+2000,"Mississippi","MS",28,64,46,"US President","Hagelin, John","natural law",FALSE,450,994184,20171015,NA
+2000,"Missouri","MO",29,43,34,"US President","Bush, George W.","republican",FALSE,1189924,2359892,20171015,NA
+2000,"Missouri","MO",29,43,34,"US President","Gore, Al","democrat",FALSE,1111138,2359892,20171015,NA
+2000,"Missouri","MO",29,43,34,"US President","Nader, Ralph","green",FALSE,38515,2359892,20171015,NA
+2000,"Missouri","MO",29,43,34,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,9818,2359892,20171015,NA
+2000,"Missouri","MO",29,43,34,"US President","Browne, Harry","libertarian",FALSE,7436,2359892,20171015,NA
+2000,"Missouri","MO",29,43,34,"US President","Phillips, Howard","constitution party",FALSE,1957,2359892,20171015,NA
+2000,"Missouri","MO",29,43,34,"US President","Hagelin, John","natural law",FALSE,1104,2359892,20171015,NA
+2000,"Montana","MT",30,81,64,"US President","Bush, George W.","republican",FALSE,240178,410986,20171015,NA
+2000,"Montana","MT",30,81,64,"US President","Gore, Al","democrat",FALSE,137126,410986,20171015,NA
+2000,"Montana","MT",30,81,64,"US President","Nader, Ralph","green",FALSE,24437,410986,20171015,NA
+2000,"Montana","MT",30,81,64,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,5697,410986,20171015,NA
+2000,"Montana","MT",30,81,64,"US President","Browne, Harry","libertarian",FALSE,1718,410986,20171015,NA
+2000,"Montana","MT",30,81,64,"US President","Phillips, Howard","constitution party",FALSE,1155,410986,20171015,NA
+2000,"Montana","MT",30,81,64,"US President","Hagelin, John","natural law",FALSE,675,410986,20171015,NA
+2000,"Nebraska","NE",31,46,35,"US President","Bush, George W.","republican",FALSE,433862,697019,20171015,NA
+2000,"Nebraska","NE",31,46,35,"US President","Gore, Al","democrat",FALSE,231780,697019,20171015,NA
+2000,"Nebraska","NE",31,46,35,"US President","Nader, Ralph","green",FALSE,24540,697019,20171015,NA
+2000,"Nebraska","NE",31,46,35,"US President","","nominated by petition",FALSE,4114,697019,20171015,NA
+2000,"Nebraska","NE",31,46,35,"US President","Browne, Harry","libertarian",FALSE,2245,697019,20171015,NA
+2000,"Nebraska","NE",31,46,35,"US President","","natural law",FALSE,478,967019,20171015,NA
+2000,"Nevada","NV",32,88,65,"US President","Bush, George W.","republican",FALSE,301575,609426,20171015,NA
+2000,"Nevada","NV",32,88,65,"US President","Gore, Al","democrat",FALSE,279978,609426,20171015,NA
+2000,"Nevada","NV",32,88,65,"US President","Nader, Ralph","green",FALSE,15008,609426,20171015,NA
+2000,"Nevada","NV",32,88,65,"US President","Buchanan, Patrick """"Pat""""","citizens first",FALSE,4747,609426,20171015,NA
+2000,"Nevada","NV",32,88,65,"US President","None Of These Candidates","",FALSE,3315,609426,20171015,NA
+2000,"Nevada","NV",32,88,65,"US President","Browne, Harry","libertarian",FALSE,3311,609426,20171015,NA
+2000,"Nevada","NV",32,88,65,"US President","Phillips, Howard","independent american",FALSE,621,609426,20171015,NA
+2000,"Nevada","NV",32,88,65,"US President","Hagelin, John","natural law",FALSE,415,609426,20171015,NA
+2000,"Nevada","NV",32,88,65,"US President","Blank Vote","",FALSE,282,609426,20171015,NA
+2000,"Nevada","NV",32,88,65,"US President","Over Vote","",FALSE,174,609426,20171015,NA
+2000,"New Hampshire","NH",33,12,4,"US President","Bush, George W.","republican",FALSE,273559,569081,20171015,NA
+2000,"New Hampshire","NH",33,12,4,"US President","Gore, Al","democrat",FALSE,266348,569081,20171015,NA
+2000,"New Hampshire","NH",33,12,4,"US President","Nader, Ralph","green",FALSE,22198,569081,20171015,NA
+2000,"New Hampshire","NH",33,12,4,"US President","Browne, Harry","libertarian",FALSE,2757,569081,20171015,NA
+2000,"New Hampshire","NH",33,12,4,"US President","Buchanan, Patrick """"Pat""""","independence",FALSE,2615,569081,20171015,NA
+2000,"New Hampshire","NH",33,12,4,"US President","","",TRUE,1276,569081,20171015,NA
+2000,"New Hampshire","NH",33,12,4,"US President","","constitution party",FALSE,328,569081,20171015,NA
+2000,"New Jersey","NJ",34,22,12,"US President","Gore, Al","democrat",FALSE,1788850,3187226,20171015,NA
+2000,"New Jersey","NJ",34,22,12,"US President","Bush, George W.","republican",FALSE,1284173,3187226,20171015,NA
+2000,"New Jersey","NJ",34,22,12,"US President","","independent",FALSE,114203,3187226,20171015,NA
+2000,"New Mexico","NM",35,85,66,"US President","Gore, Al","democrat",FALSE,286783,598605,20171015,NA
+2000,"New Mexico","NM",35,85,66,"US President","Bush, George W.","republican",FALSE,286417,598605,20171015,NA
+2000,"New Mexico","NM",35,85,66,"US President","Nader, Ralph","green",FALSE,21251,598605,20171015,NA
+2000,"New Mexico","NM",35,85,66,"US President","Browne, Harry","libertarian",FALSE,2058,598605,20171015,NA
+2000,"New Mexico","NM",35,85,66,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,1392,598605,20171015,NA
+2000,"New Mexico","NM",35,85,66,"US President","Hagelin, John","natural law",FALSE,361,598605,20171015,NA
+2000,"New Mexico","NM",35,85,66,"US President","Phillips, Howard","constitution party",FALSE,343,598605,20171015,NA
+2000,"New York","NY",36,21,13,"US President","Gore, Al","democrat",FALSE,3942215,6960215,20171015,NA
+2000,"New York","NY",36,21,13,"US President","Bush, George W.","republican",FALSE,2258577,6960215,20171015,NA
+2000,"New York","NY",36,21,13,"US President","Nader, Ralph","green",FALSE,244030,6960215,20171015,NA
+2000,"New York","NY",36,21,13,"US President","Bush, George W.","conservative",FALSE,144797,6960215,20171015,NA
+2000,"New York","NY",36,21,13,"US President","Blank Vote/Scattering","",FALSE,138216,6960215,20171015,NA
+2000,"New York","NY",36,21,13,"US President","Gore, Al","working families",FALSE,88395,6960215,20171015,NA
+2000,"New York","NY",36,21,13,"US President","Gore, Al","liberal party",FALSE,77087,6960215,20171015,NA
+2000,"New York","NY",36,21,13,"US President","Buchanan, Patrick """"Pat""""","right-to-life",FALSE,25175,6960215,20171015,NA
+2000,"New York","NY",36,21,13,"US President","Hagelin, John","independence",FALSE,24361,6960215,20171015,NA
+2000,"New York","NY",36,21,13,"US President","Browne, Harry","libertarian",FALSE,7649,6960215,20171015,NA
+2000,"New York","NY",36,21,13,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,6424,6960215,20171015,NA
+2000,"New York","NY",36,21,13,"US President","Harris, James","socialist workers",FALSE,1789,6960215,20171015,NA
+2000,"New York","NY",36,21,13,"US President","Phillips, Howard","constitution party",FALSE,1498,6960215,20171015,NA
+2000,"New York","NY",36,21,13,"US President","","socialist",TRUE,2,6960215,20171015,NA
+2000,"North Carolina","NC",37,56,47,"US President","Bush, George W.","republican",FALSE,1631163,2914990,20171015,NA
+2000,"North Carolina","NC",37,56,47,"US President","Gore, Al","democrat",FALSE,1257692,2914990,20171015,NA
+2000,"North Carolina","NC",37,56,47,"US President","Browne, Harry","libertarian",FALSE,13891,2914990,20171015,NA
+2000,"North Carolina","NC",37,56,47,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,8874,2914990,20171015,NA
+2000,"North Carolina","NC",37,56,47,"US President","Not Designated","socialist",FALSE,3370,2914990,20171015,NA
+2000,"North Dakota","ND",38,44,36,"US President","Bush, George W.","republican",FALSE,174852,288256,20171015,NA
+2000,"North Dakota","ND",38,44,36,"US President","Gore, Al","democrat",FALSE,95284,288256,20171015,NA
+2000,"North Dakota","ND",38,44,36,"US President","","independent",FALSE,10459,288256,20171015,NA
+2000,"North Dakota","ND",38,44,36,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,7288,288256,20171015,NA
+2000,"North Dakota","ND",38,44,36,"US President","Phillips, Howard","constitution party",FALSE,373,288256,20171015,NA
+2000,"Ohio","OH",39,31,24,"US President","Bush, George W.","republican",FALSE,2350363,4701998,20171015,NA
+2000,"Ohio","OH",39,31,24,"US President","Gore, Al","democrat",FALSE,2183628,4701998,20171015,NA
+2000,"Ohio","OH",39,31,24,"US President","Not Designated","",FALSE,148353,4701998,20171015,NA
+2000,"Ohio","OH",39,31,24,"US President","Browne, Harry","libertarian",FALSE,13473,4701998,20171015,NA
+2000,"Ohio","OH",39,31,24,"US President","Hagelin, John","natural law",FALSE,6181,4701998,20171015,NA
+2000,"Oklahoma","OK",40,73,53,"US President","Bush, George W.","republican",FALSE,744337,1234229,20171015,NA
+2000,"Oklahoma","OK",40,73,53,"US President","Gore, Al","democrat",FALSE,474276,1234229,20171015,NA
+2000,"Oklahoma","OK",40,73,53,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,9014,1234229,20171015,NA
+2000,"Oklahoma","OK",40,73,53,"US President","Browne, Harry","libertarian",FALSE,6602,1234229,20171015,NA
+2000,"Oregon","OR",41,92,72,"US President","Gore, Al","democrat",FALSE,720342,1533950,20171015,NA
+2000,"Oregon","OR",41,92,72,"US President","Bush, George W.","republican",FALSE,713577,1533950,20171015,NA
+2000,"Oregon","OR",41,92,72,"US President","Nader, Ralph","green",FALSE,77357,1533950,20171015,NA
+2000,"Oregon","OR",41,92,72,"US President","Browne, Harry","libertarian",FALSE,7447,1533950,20171015,NA
+2000,"Oregon","OR",41,92,72,"US President","Buchanan, Patrick """"Pat""""","independent",FALSE,7063,1533950,20171015,NA
+2000,"Oregon","OR",41,92,72,"US President","Other","",FALSE,3401,1533950,20171015,NA
+2000,"Oregon","OR",41,92,72,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,2574,1533950,20171015,NA
+2000,"Oregon","OR",41,92,72,"US President","Phillips, Howard","constitution party",FALSE,2189,1533950,20171015,NA
+2000,"Pennsylvania","PA",42,23,14,"US President","Gore, Al","democrat",FALSE,2485967,4912185,20171015,NA
+2000,"Pennsylvania","PA",42,23,14,"US President","Bush, George W.","republican",FALSE,2281127,4912185,20171015,NA
+2000,"Pennsylvania","PA",42,23,14,"US President","Nader, Ralph","green",FALSE,103392,4912185,20171015,NA
+2000,"Pennsylvania","PA",42,23,14,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,16023,4912185,20171015,NA
+2000,"Pennsylvania","PA",42,23,14,"US President","Phillips, Howard","constitution party",FALSE,14428,4912185,20171015,NA
+2000,"Pennsylvania","PA",42,23,14,"US President","Browne, Harry","libertarian",FALSE,11248,4912185,20171015,NA
+2000,"Rhode Island","RI",44,15,5,"US President","Gore, Al","democrat",FALSE,249508,409112,20171015,NA
+2000,"Rhode Island","RI",44,15,5,"US President","Bush, George W.","republican",FALSE,130555,409112,20171015,NA
+2000,"Rhode Island","RI",44,15,5,"US President","Nader, Ralph","green",FALSE,25052,409112,20171015,NA
+2000,"Rhode Island","RI",44,15,5,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,2273,409112,20171015,NA
+2000,"Rhode Island","RI",44,15,5,"US President","Browne, Harry","libertarian",FALSE,742,409112,20171015,NA
+2000,"Rhode Island","RI",44,15,5,"US President","","",TRUE,329,409112,20171015,NA
+2000,"Rhode Island","RI",44,15,5,"US President","Hagelin, John","natural law",FALSE,271,409112,20171015,NA
+2000,"Rhode Island","RI",44,15,5,"US President","Moorehead, Monica","workers world",FALSE,199,409112,20171015,NA
+2000,"Rhode Island","RI",44,15,5,"US President","Phillips, Howard","constitution party",FALSE,97,409112,20171015,NA
+2000,"Rhode Island","RI",44,15,5,"US President","","socialist",FALSE,52,409112,20171015,NA
+2000,"Rhode Island","RI",44,15,5,"US President","","socialist workers",FALSE,34,409112,20171015,NA
+2000,"South Carolina","SC",45,57,48,"US President","Bush, George W.","republican",FALSE,786892,1383902,20171015,NA
+2000,"South Carolina","SC",45,57,48,"US President","Gore, Al","democrat",FALSE,566037,1383902,20171015,NA
+2000,"South Carolina","SC",45,57,48,"US President","Nader, Ralph","united citizens",FALSE,20279,1383902,20171015,NA
+2000,"South Carolina","SC",45,57,48,"US President","Browne, Harry","libertarian",FALSE,4760,1383902,20171015,NA
+2000,"South Carolina","SC",45,57,48,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,3309,1383902,20171015,NA
+2000,"South Carolina","SC",45,57,48,"US President","","constitution party",FALSE,1682,1383902,20171015,NA
+2000,"South Carolina","SC",45,57,48,"US President","Hagelin, John","natural law",FALSE,943,1383902,20171015,NA
+2000,"South Dakota","SD",46,45,37,"US President","Bush, George W.","republican",FALSE,190700,316269,20171015,NA
+2000,"South Dakota","SD",46,45,37,"US President","Gore, Al","democrat",FALSE,118804,316269,20171015,NA
+2000,"South Dakota","SD",46,45,37,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,3322,316269,20171015,NA
+2000,"South Dakota","SD",46,45,37,"US President","Phillips, Howard","independent",FALSE,1781,316269,20171015,NA
+2000,"South Dakota","SD",46,45,37,"US President","Browne, Harry","libertarian",FALSE,1662,316269,20171015,NA
+2000,"Tennessee","TN",47,62,54,"US President","Bush, George W.","republican",FALSE,1061949,2076181,20171015,NA
+2000,"Tennessee","TN",47,62,54,"US President","Gore, Al","democrat",FALSE,981720,2076181,20171015,NA
+2000,"Tennessee","TN",47,62,54,"US President","","independent",FALSE,32084,2076181,20171015,NA
+2000,"Tennessee","TN",47,62,54,"US President","","",TRUE,428,2076181,20171015,NA
+2000,"Texas","TX",48,74,49,"US President","Bush, George W.","republican",FALSE,3799639,6407637,20171015,NA
+2000,"Texas","TX",48,74,49,"US President","Gore, Al","democrat",FALSE,2433746,6407637,20171015,NA
+2000,"Texas","TX",48,74,49,"US President","Nader, Ralph","green",FALSE,137994,6407637,20171015,NA
+2000,"Texas","TX",48,74,49,"US President","Browne, Harry","libertarian",FALSE,23160,6407637,20171015,NA
+2000,"Texas","TX",48,74,49,"US President","","independent",FALSE,12394,6407637,20171015,NA
+2000,"Texas","TX",48,74,49,"US President","","",TRUE,704,6407637,20171015,NA
+2000,"Utah","UT",49,87,67,"US President","Bush, George W.","republican",FALSE,515096,770754,20171015,NA
+2000,"Utah","UT",49,87,67,"US President","Gore, Al","democrat",FALSE,203053,770754,20171015,NA
+2000,"Utah","UT",49,87,67,"US President","Nader, Ralph","green",FALSE,35850,770754,20171015,NA
+2000,"Utah","UT",49,87,67,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,9319,770754,20171015,NA
+2000,"Utah","UT",49,87,67,"US President","Browne, Harry","libertarian",FALSE,3616,770754,20171015,NA
+2000,"Utah","UT",49,87,67,"US President","Phillips, Howard","independent american",FALSE,2709,770754,20171015,NA
+2000,"Utah","UT",49,87,67,"US President","Hagelin, John","natural law",FALSE,763,770754,20171015,NA
+2000,"Utah","UT",49,87,67,"US President","Harris, James","socialist workers",FALSE,186,770754,20171015,NA
+2000,"Utah","UT",49,87,67,"US President","","no party affiliation",FALSE,161,770754,20171015,NA
+2000,"Utah","UT",49,87,67,"US President","","",TRUE,1,770754,20171015,NA
+2000,"Vermont","VT",50,13,6,"US President","Gore, Al","democrat",FALSE,149022,294308,20171015,NA
+2000,"Vermont","VT",50,13,6,"US President","Bush, George W.","republican",FALSE,119775,294308,20171015,NA
+2000,"Vermont","VT",50,13,6,"US President","Nader, Ralph","progressive/green",FALSE,20374,294308,20171015,NA
+2000,"Vermont","VT",50,13,6,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,2192,294308,20171015,NA
+2000,"Vermont","VT",50,13,6,"US President","Dennis """"Denny"""", Lane","vermont grassroots",FALSE,1044,294308,20171015,NA
+2000,"Vermont","VT",50,13,6,"US President","Browne, Harry","libertarian",FALSE,784,294308,20171015,NA
+2000,"Vermont","VT",50,13,6,"US President","","",TRUE,514,294308,20171015,NA
+2000,"Vermont","VT",50,13,6,"US President","Hagelin, John","natural law",FALSE,219,294308,20171015,NA
+2000,"Vermont","VT",50,13,6,"US President","McReynolds, David","liberty union party",FALSE,161,294308,20171015,NA
+2000,"Vermont","VT",50,13,6,"US President","Phillips, Howard","constitution party",FALSE,153,294308,20171015,NA
+2000,"Vermont","VT",50,13,6,"US President","Harris, James","socialist workers",FALSE,70,294308,20171015,NA
+2000,"Virginia","VA",51,54,40,"US President","Bush, George W.","republican",FALSE,1437490,2739447,20171015,NA
+2000,"Virginia","VA",51,54,40,"US President","Gore, Al","democrat",FALSE,1217290,2739447,20171015,NA
+2000,"Virginia","VA",51,54,40,"US President","Nader, Ralph","green",FALSE,59398,2739447,20171015,NA
+2000,"Virginia","VA",51,54,40,"US President","Browne, Harry","libertarian",FALSE,15198,2739447,20171015,NA
+2000,"Virginia","VA",51,54,40,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,5455,2739447,20171015,NA
+2000,"Virginia","VA",51,54,40,"US President","","",TRUE,2807,2739447,20171015,NA
+2000,"Virginia","VA",51,54,40,"US President","Phillips, Howard","conservative",FALSE,1809,2739447,20171015,NA
+2000,"Washington","WA",53,91,73,"US President","Gore, Al","democrat",FALSE,1247652,2487433,20171015,NA
+2000,"Washington","WA",53,91,73,"US President","Bush, George W.","republican",FALSE,1108864,2487433,20171015,NA
+2000,"Washington","WA",53,91,73,"US President","Nader, Ralph","green",FALSE,103002,2487433,20171015,NA
+2000,"Washington","WA",53,91,73,"US President","Browne, Harry","libertarian",FALSE,13135,2487433,20171015,NA
+2000,"Washington","WA",53,91,73,"US President","Buchanan, Patrick """"Pat""""","freedom",FALSE,7171,2487433,20171015,NA
+2000,"Washington","WA",53,91,73,"US President","Hagelin, John","natural law",FALSE,2927,2487433,20171015,NA
+2000,"Washington","WA",53,91,73,"US President","Phillips, Howard","constitution party",FALSE,1989,2487433,20171015,NA
+2000,"Washington","WA",53,91,73,"US President","Moorehead, Monica","workers world",FALSE,1729,2487433,20171015,NA
+2000,"Washington","WA",53,91,73,"US President","McReynolds, David","socialist",FALSE,660,2487433,20171015,NA
+2000,"Washington","WA",53,91,73,"US President","Harris, James","socialist workers",FALSE,304,2487433,20171015,NA
+2000,"West Virginia","WV",54,55,56,"US President","Bush, George W.","republican",FALSE,336475,648124,20171015,NA
+2000,"West Virginia","WV",54,55,56,"US President","Gore, Al","democrat",FALSE,295497,648124,20171015,NA
+2000,"West Virginia","WV",54,55,56,"US President","Nader, Ralph","green",FALSE,10680,648124,20171015,NA
+2000,"West Virginia","WV",54,55,56,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,3169,648124,20171015,NA
+2000,"West Virginia","WV",54,55,56,"US President","Browne, Harry","libertarian",FALSE,1912,648124,20171015,NA
+2000,"West Virginia","WV",54,55,56,"US President","Hagelin, John","natural law",FALSE,367,648124,20171015,NA
+2000,"West Virginia","WV",54,55,56,"US President","","",TRUE,24,648124,20171015,NA
+2000,"Wisconsin","WI",55,35,25,"US President","Gore, Al","democrat",FALSE,1242987,2598607,20171015,NA
+2000,"Wisconsin","WI",55,35,25,"US President","Bush, George W.","republican",FALSE,1237279,2598607,20171015,NA
+2000,"Wisconsin","WI",55,35,25,"US President","Nader, Ralph","green",FALSE,94070,2598607,20171015,NA
+2000,"Wisconsin","WI",55,35,25,"US President","","independent",FALSE,13693,2598607,20171015,NA
+2000,"Wisconsin","WI",55,35,25,"US President","Browne, Harry","libertarian",FALSE,6640,2598607,20171015,NA
+2000,"Wisconsin","WI",55,35,25,"US President","","constitution party",FALSE,2042,2598607,20171015,NA
+2000,"Wisconsin","WI",55,35,25,"US President","Scattering","",FALSE,1896,2598607,20171015,NA
+2000,"Wyoming","WY",56,83,68,"US President","Bush, George W.","republican",FALSE,147947,213726,20171015,NA
+2000,"Wyoming","WY",56,83,68,"US President","Gore, Al","democrat",FALSE,60481,213726,20171015,NA
+2000,"Wyoming","WY",56,83,68,"US President","Buchanan, Patrick """"Pat""""","reform party",FALSE,2724,213726,20171015,NA
+2000,"Wyoming","WY",56,83,68,"US President","Browne, Harry","libertarian",FALSE,1443,213726,20171015,NA
+2000,"Wyoming","WY",56,83,68,"US President","Phillips, Howard","independent",FALSE,720,213726,20171015,NA
+2000,"Wyoming","WY",56,83,68,"US President","Hagelin, John","natural law",FALSE,411,213726,20171015,NA
+2004,"Alabama","AL",1,63,41,"US President","Bush, George W.","republican",FALSE,1176394,1883415,20171015,NA
+2004,"Alabama","AL",1,63,41,"US President","Kerry, John","democrat",FALSE,693933,1883415,20171015,NA
+2004,"Alabama","AL",1,63,41,"US President","Other","independent",FALSE,12190,1883415,20171015,NA
+2004,"Alabama","AL",1,63,41,"US President","Other","",TRUE,898,1883415,20171015,NA
+2004,"Alaska","AK",2,94,81,"US President","Bush, George W.","republican",FALSE,190889,312598,20171015,NA
+2004,"Alaska","AK",2,94,81,"US President","Kerry, John","democrat",FALSE,111025,312598,20171015,NA
+2004,"Alaska","AK",2,94,81,"US President","Nader, Ralph","populist",FALSE,5069,312598,20171015,NA
+2004,"Alaska","AK",2,94,81,"US President","Peroutka, Michael","alaskan independence party",FALSE,2092,312598,20171015,NA
+2004,"Alaska","AK",2,94,81,"US President","Badnarik, Michael","libertarian",FALSE,1675,312598,20171015,NA
+2004,"Alaska","AK",2,94,81,"US President","Cobb, David","green",FALSE,1058,312598,20171015,NA
+2004,"Alaska","AK",2,94,81,"US President","Other","",TRUE,790,312598,20171015,NA
+2004,"Arizona","AZ",4,86,61,"US President","Bush, George W.","republican",FALSE,1104294,2012585,20171015,NA
+2004,"Arizona","AZ",4,86,61,"US President","Kerry, John","democrat",FALSE,893524,2012585,20171015,NA
+2004,"Arizona","AZ",4,86,61,"US President","Badnarik, Michael","libertarian",FALSE,11856,2012585,20171015,NA
+2004,"Arizona","AZ",4,86,61,"US President","Other","",TRUE,2911,2012585,20171015,NA
+2004,"Arkansas","AR",5,71,42,"US President","Bush, George W.","republican",FALSE,572898,1054945,20171015,NA
+2004,"Arkansas","AR",5,71,42,"US President","Kerry, John","democrat",FALSE,469953,1054945,20171015,NA
+2004,"Arkansas","AR",5,71,42,"US President","Nader, Ralph","populist",FALSE,6171,1054945,20171015,NA
+2004,"Arkansas","AR",5,71,42,"US President","Badnarik, Michael","libertarian",FALSE,2352,1054945,20171015,NA
+2004,"Arkansas","AR",5,71,42,"US President","Peroutka, Michael","constitution party",FALSE,2083,1054945,20171015,NA
+2004,"Arkansas","AR",5,71,42,"US President","Cobb, David","green",FALSE,1488,1054945,20171015,NA
+2004,"California","CA",6,93,71,"US President","Kerry, John","democrat",FALSE,6745485,12421353,20171015,NA
+2004,"California","CA",6,93,71,"US President","Bush, George W.","republican",FALSE,5509826,12421353,20171015,NA
+2004,"California","CA",6,93,71,"US President","Badnarik, Michael","libertarian",FALSE,50165,12421353,20171015,NA
+2004,"California","CA",6,93,71,"US President","Cobb, David","green",FALSE,40771,12421353,20171015,NA
+2004,"California","CA",6,93,71,"US President","Peltier, Leonard","peace & freedom",FALSE,27607,12421353,20171015,NA
+2004,"California","CA",6,93,71,"US President","Peroutka, Michael","american independent party",FALSE,26645,12421353,20171015,NA
+2004,"California","CA",6,93,71,"US President","Other","",TRUE,20854,12421353,20171015,NA
+2004,"Colorado","CO",8,84,62,"US President","Bush, George W.","republican",FALSE,1101255,2129630,20171015,NA
+2004,"Colorado","CO",8,84,62,"US President","Kerry, John","democrat",FALSE,1001732,2129630,20171015,NA
+2004,"Colorado","CO",8,84,62,"US President","Nader, Ralph","reform party",FALSE,12718,2129630,20171015,NA
+2004,"Colorado","CO",8,84,62,"US President","Badnarik, Michael","libertarian",FALSE,7664,2129630,20171015,NA
+2004,"Colorado","CO",8,84,62,"US President","Peroutka, Michael","american constitution party",FALSE,2562,2129630,20171015,NA
+2004,"Colorado","CO",8,84,62,"US President","Cobb, David","green",FALSE,1591,2129630,20171015,NA
+2004,"Colorado","CO",8,84,62,"US President","Andress, Stanford","unaffiliated",FALSE,804,2129630,20171015,NA
+2004,"Colorado","CO",8,84,62,"US President","Amondson, Gene","concerns of people",FALSE,378,2129630,20171015,NA
+2004,"Colorado","CO",8,84,62,"US President","Van Auken, Bill","socialist equality party",FALSE,329,2129630,20171015,NA
+2004,"Colorado","CO",8,84,62,"US President","Calero, Roger","socialist workers",FALSE,241,2129630,20171015,NA
+2004,"Colorado","CO",8,84,62,"US President","Brown, Walt","socialist",FALSE,216,2129630,20171015,NA
+2004,"Colorado","CO",8,84,62,"US President","Dodge, Earl","prohibition",FALSE,140,2129630,20171015,NA
+2004,"Connecticut","CT",9,16,1,"US President","Kerry, John","democrat",FALSE,857488,1578769,20171015,NA
+2004,"Connecticut","CT",9,16,1,"US President","Bush, George W.","republican",FALSE,693826,1578769,20171015,NA
+2004,"Connecticut","CT",9,16,1,"US President","Nader, Ralph","petitioning candidate",FALSE,12969,1578769,20171015,NA
+2004,"Connecticut","CT",9,16,1,"US President","Cobb, David","green",FALSE,9564,1578769,20171015,NA
+2004,"Connecticut","CT",9,16,1,"US President","Badnarik, Michael","libertarian",FALSE,3367,1578769,20171015,NA
+2004,"Connecticut","CT",9,16,1,"US President","Peroutka, Michael","concerned citizens",FALSE,1543,1578769,20171015,NA
+2004,"Connecticut","CT",9,16,1,"US President","Calero, Roger","socialist workers",TRUE,12,1578769,20171015,NA
+2004,"Delaware","DE",10,51,11,"US President","Kerry, John","democrat",FALSE,200152,375190,20171015,NA
+2004,"Delaware","DE",10,51,11,"US President","Bush, George W.","republican",FALSE,171660,375190,20171015,NA
+2004,"Delaware","DE",10,51,11,"US President","Nader, Ralph","independent",FALSE,2153,375190,20171015,NA
+2004,"Delaware","DE",10,51,11,"US President","Badnarik, Michael","libertarian",FALSE,586,375190,20171015,NA
+2004,"Delaware","DE",10,51,11,"US President","Peroutka, Michael","constitution party",FALSE,289,375190,20171015,NA
+2004,"Delaware","DE",10,51,11,"US President","Cobb, David","green",FALSE,250,375190,20171015,NA
+2004,"Delaware","DE",10,51,11,"US President","Brown, Walt","natural law",FALSE,100,375190,20171015,NA
+2004,"District of Columbia","DC",11,53,55,"US President","Kerry, John","democrat",FALSE,202970,227586,20171015,NA
+2004,"District of Columbia","DC",11,53,55,"US President","Bush, George W.","republican",FALSE,21256,227586,20171015,NA
+2004,"District of Columbia","DC",11,53,55,"US President","Nader, Ralph","independent",FALSE,1485,227586,20171015,NA
+2004,"District of Columbia","DC",11,53,55,"US President","Cobb, David","d.c. statehood green",FALSE,737,227586,20171015,NA
+2004,"District of Columbia","DC",11,53,55,"US President","Others","",TRUE,506,227586,20171015,NA
+2004,"District of Columbia","DC",11,53,55,"US President","Badnarik, Michael","libertarian",FALSE,502,227586,20171015,NA
+2004,"District of Columbia","DC",11,53,55,"US President","Calero, Roger","socialist workers",FALSE,130,227586,20171015,NA
+2004,"Florida","FL",12,59,43,"US President","Bush, George W.","republican",FALSE,3964522,7609810,20171015,NA
+2004,"Florida","FL",12,59,43,"US President","Kerry, John","democrat",FALSE,3583544,7609810,20171015,NA
+2004,"Florida","FL",12,59,43,"US President","Nader, Ralph","reform party",FALSE,32971,7609810,20171015,NA
+2004,"Florida","FL",12,59,43,"US President","Badnarik, Michael","libertarian",FALSE,11996,7609810,20171015,NA
+2004,"Florida","FL",12,59,43,"US President","Peroutka, Michael","constitution party of florida",FALSE,6626,7609810,20171015,NA
+2004,"Florida","FL",12,59,43,"US President","Cobb, David","green",FALSE,3917,7609810,20171015,NA
+2004,"Florida","FL",12,59,43,"US President","Brown, Walt","socialist party of florida",FALSE,3502,7609810,20171015,NA
+2004,"Florida","FL",12,59,43,"US President","Calero, Roger","socialist workers",FALSE,2732,7609810,20171015,NA
+2004,"Georgia","GA",13,58,44,"US President","Bush, George W.","republican",FALSE,1914254,3301875,20171015,NA
+2004,"Georgia","GA",13,58,44,"US President","Kerry, John","democrat",FALSE,1366149,3301875,20171015,NA
+2004,"Georgia","GA",13,58,44,"US President","Badnarik, Michael","libertarian",FALSE,18387,3301875,20171015,NA
+2004,"Georgia","GA",13,58,44,"US President","Other","",TRUE,3085,3301875,20171015,NA
+2004,"Hawaii","HI",15,95,82,"US President","Kerry, John","democrat",FALSE,231708,429013,20171015,NA
+2004,"Hawaii","HI",15,95,82,"US President","Bush, George W.","republican",FALSE,194191,429013,20171015,NA
+2004,"Hawaii","HI",15,95,82,"US President","Cobb, David","green",FALSE,1737,429013,20171015,NA
+2004,"Hawaii","HI",15,95,82,"US President","Badnarik, Michael","libertarian",FALSE,1377,429013,20171015,NA
+2004,"Idaho","ID",16,82,63,"US President","Bush, George W.","republican",FALSE,409235,598376,20171015,NA
+2004,"Idaho","ID",16,82,63,"US President","Kerry, John","democrat",FALSE,181098,598376,20171015,NA
+2004,"Idaho","ID",16,82,63,"US President","Badnarik, Michael","libertarian",FALSE,3844,598376,20171015,NA
+2004,"Idaho","ID",16,82,63,"US President","Peroutka, Michael","constitution party",FALSE,3084,598376,20171015,NA
+2004,"Idaho","ID",16,82,63,"US President","Nader, Ralph","independent",FALSE,1115,598376,20171015,NA
+2004,"Illinois","IL",17,33,21,"US President","Kerry, John","democrat",FALSE,2891550,5274322,20171015,NA
+2004,"Illinois","IL",17,33,21,"US President","Bush, George W.","republican",FALSE,2345946,5274322,20171015,NA
+2004,"Illinois","IL",17,33,21,"US President","Badnarik, Michael","libertarian",FALSE,32442,5274322,20171015,NA
+2004,"Illinois","IL",17,33,21,"US President","Other","",TRUE,4384,5274322,20171015,NA
+2004,"Indiana","IN",18,32,22,"US President","Bush, George W.","republican",FALSE,1479438,2468002,20171015,NA
+2004,"Indiana","IN",18,32,22,"US President","Kerry, John","democrat",FALSE,969011,2468002,20171015,NA
+2004,"Indiana","IN",18,32,22,"US President","Badnarik, Michael","libertarian",FALSE,18058,2468002,20171015,NA
+2004,"Indiana","IN",18,32,22,"US President","Other","",TRUE,1495,2468002,20171015,NA
+2004,"Iowa","IA",19,42,31,"US President","Bush, George W.","republican",FALSE,751957,1506908,20171015,NA
+2004,"Iowa","IA",19,42,31,"US President","Kerry, John","democrat",FALSE,741898,1506908,20171015,NA
+2004,"Iowa","IA",19,42,31,"US President","Other","",FALSE,6149,1506908,20171015,NA
+2004,"Iowa","IA",19,42,31,"US President","Badnarik, Michael","libertarian",FALSE,2992,1506908,20171015,NA
+2004,"Iowa","IA",19,42,31,"US President","Peroutka, Michael","constitution party",FALSE,1304,1506908,20171015,NA
+2004,"Iowa","IA",19,42,31,"US President","Cobb, David","green",FALSE,1141,1506908,20171015,NA
+2004,"Iowa","IA",19,42,31,"US President","Other","",TRUE,1094,1506908,20171015,NA
+2004,"Iowa","IA",19,42,31,"US President","Calero, Roger","socialist workers",FALSE,373,1506908,20171015,NA
+2004,"Kansas","KS",20,47,32,"US President","Bush, George W.","republican",FALSE,736456,1187756,20171015,NA
+2004,"Kansas","KS",20,47,32,"US President","Kerry, John","democrat",FALSE,434993,1187756,20171015,NA
+2004,"Kansas","KS",20,47,32,"US President","Nader, Ralph","reform party",FALSE,9348,1187756,20171015,NA
+2004,"Kansas","KS",20,47,32,"US President","Badnarik, Michael","libertarian",FALSE,4013,1187756,20171015,NA
+2004,"Kansas","KS",20,47,32,"US President","Peroutka, Michael","independent",FALSE,2899,1187756,20171015,NA
+2004,"Kansas","KS",20,47,32,"US President","Other","",TRUE,47,1187756,20171015,NA
+2004,"Kentucky","KY",21,61,51,"US President","Bush, George W.","republican",FALSE,1069439,1795882,20171015,NA
+2004,"Kentucky","KY",21,61,51,"US President","Kerry, John","democrat",FALSE,712733,1795882,20171015,NA
+2004,"Kentucky","KY",21,61,51,"US President","Nader, Ralph","independent",FALSE,8856,1795882,20171015,NA
+2004,"Kentucky","KY",21,61,51,"US President","Badnarik, Michael","libertarian",FALSE,2619,1795882,20171015,NA
+2004,"Kentucky","KY",21,61,51,"US President","Peroutka, Michael","constitution party",FALSE,2213,1795882,20171015,NA
+2004,"Kentucky","KY",21,61,51,"US President","Other","",TRUE,22,1795882,20171015,NA
+2004,"Louisiana","LA",22,72,45,"US President","Bush, George W.","republican",FALSE,1102169,1943106,20171015,NA
+2004,"Louisiana","LA",22,72,45,"US President","Kerry, John","democrat",FALSE,820299,1943106,20171015,NA
+2004,"Louisiana","LA",22,72,45,"US President","Nader, Ralph","independent",FALSE,7032,1943106,20171015,NA
+2004,"Louisiana","LA",22,72,45,"US President","Peroutka, Michael","constitution party",FALSE,5203,1943106,20171015,NA
+2004,"Louisiana","LA",22,72,45,"US President","Badnarik, Michael","libertarian",FALSE,2781,1943106,20171015,NA
+2004,"Louisiana","LA",22,72,45,"US President","Brown, Walt","protecting working families",FALSE,1795,1943106,20171015,NA
+2004,"Louisiana","LA",22,72,45,"US President","Amondson, Gene","prohibition",FALSE,1566,1943106,20171015,NA
+2004,"Louisiana","LA",22,72,45,"US President","Cobb, David","green",FALSE,1276,1943106,20171015,NA
+2004,"Louisiana","LA",22,72,45,"US President","Calero, Roger","socialist",FALSE,985,1943106,20171015,NA
+2004,"Maine","ME",23,11,2,"US President","Kerry, John","democrat",FALSE,396842,740752,20171015,NA
+2004,"Maine","ME",23,11,2,"US President","Bush, George W.","republican",FALSE,330201,740752,20171015,NA
+2004,"Maine","ME",23,11,2,"US President","The Better Life,","independent",FALSE,8069,740752,20171015,NA
+2004,"Maine","ME",23,11,2,"US President","Cobb, David","green",FALSE,2936,740752,20171015,NA
+2004,"Maine","ME",23,11,2,"US President","Badnarik, Michael","libertarian",FALSE,1965,740752,20171015,NA
+2004,"Maine","ME",23,11,2,"US President","Peroutka, Michael","constitution party",FALSE,735,740752,20171015,NA
+2004,"Maine","ME",23,11,2,"US President","Blank Vote/Scattering","",FALSE,4,740752,20171015,NA
+2004,"Maryland","MD",24,52,52,"US President","Kerry, John","democrat",FALSE,1334493,2384238,20171015,NA
+2004,"Maryland","MD",24,52,52,"US President","Bush, George W.","republican",FALSE,1024703,2384238,20171015,NA
+2004,"Maryland","MD",24,52,52,"US President","Nader, Ralph","populist",FALSE,11854,2384238,20171015,NA
+2004,"Maryland","MD",24,52,52,"US President","Badnarik, Michael","libertarian",FALSE,6094,2384238,20171015,NA
+2004,"Maryland","MD",24,52,52,"US President","Cobb, David","green",FALSE,3632,2384238,20171015,NA
+2004,"Maryland","MD",24,52,52,"US President","Peroutka, Michael","constitution party",FALSE,3421,2384238,20171015,NA
+2004,"Maryland","MD",24,52,52,"US President","Other","unaffiliated",TRUE,34,2384238,20171015,NA
+2004,"Maryland","MD",24,52,52,"US President","Other","democrat",TRUE,7,2384238,20171015,NA
+2004,"Massachusetts","MA",25,14,3,"US President","Kerry, John","democrat",FALSE,1803800,2927455,20171015,NA
+2004,"Massachusetts","MA",25,14,3,"US President","Bush, George W.","republican",FALSE,1071109,2927455,20171015,NA
+2004,"Massachusetts","MA",25,14,3,"US President","Blank Vote/Scattering","",FALSE,15067,2927455,20171015,NA
+2004,"Massachusetts","MA",25,14,3,"US President","Badnarik, Michael","libertarian",FALSE,15022,2927455,20171015,NA
+2004,"Massachusetts","MA",25,14,3,"US President","Cobb, David","green-rainbow",FALSE,10623,2927455,20171015,NA
+2004,"Massachusetts","MA",25,14,3,"US President","Other","",FALSE,7028,2927455,20171015,NA
+2004,"Massachusetts","MA",25,14,3,"US President","Nader, Ralph","independent",TRUE,4806,2927455,20171015,NA
+2004,"Michigan","MI",26,34,23,"US President","Kerry, John","democrat",FALSE,2479183,4839252,20171015,NA
+2004,"Michigan","MI",26,34,23,"US President","Bush, George W.","republican",FALSE,2313746,4839252,20171015,NA
+2004,"Michigan","MI",26,34,23,"US President","Nader, Ralph","no party affiliation",FALSE,24035,4839252,20171015,NA
+2004,"Michigan","MI",26,34,23,"US President","Badnarik, Michael","libertarian",FALSE,10552,4839252,20171015,NA
+2004,"Michigan","MI",26,34,23,"US President","Cobb, David","green",FALSE,5325,4839252,20171015,NA
+2004,"Michigan","MI",26,34,23,"US President","Peroutka, Michael","u.s. taxpayers party",FALSE,4980,4839252,20171015,NA
+2004,"Michigan","MI",26,34,23,"US President","Brown, Walt","natural law",FALSE,1431,4839252,20171015,NA
+2004,"Minnesota","MN",27,41,33,"US President","Kerry, John","democratic-farmer-labor",FALSE,1445014,2828387,20171015,NA
+2004,"Minnesota","MN",27,41,33,"US President","Bush, George W.","republican",FALSE,1346695,2828387,20171015,NA
+2004,"Minnesota","MN",27,41,33,"US President","Nader, Ralph","better life",FALSE,18683,2828387,20171015,NA
+2004,"Minnesota","MN",27,41,33,"US President","Badnarik, Michael","libertarian",FALSE,4639,2828387,20171015,NA
+2004,"Minnesota","MN",27,41,33,"US President","Cobb, David","green",FALSE,4408,2828387,20171015,NA
+2004,"Minnesota","MN",27,41,33,"US President","Peroutka, Michael","constitution party",FALSE,3074,2828387,20171015,NA
+2004,"Minnesota","MN",27,41,33,"US President","Other","",TRUE,2532,2828387,20171015,NA
+2004,"Minnesota","MN",27,41,33,"US President","Harens, Thomas","christian freedom party",FALSE,2387,2828387,20171015,NA
+2004,"Minnesota","MN",27,41,33,"US President","Van Auken, Bill","socialist equality party",FALSE,539,2828387,20171015,NA
+2004,"Minnesota","MN",27,41,33,"US President","Calero, Roger","socialist workers",FALSE,416,2828387,20171015,NA
+2004,"Mississippi","MS",28,64,46,"US President","Bush, George W.","republican",FALSE,672660,1139824,20171015,NA
+2004,"Mississippi","MS",28,64,46,"US President","Kerry, John","democrat",FALSE,457766,1139824,20171015,NA
+2004,"Mississippi","MS",28,64,46,"US President","Nader, Ralph","reform party",FALSE,3175,1139824,20171015,NA
+2004,"Mississippi","MS",28,64,46,"US President","Badnarik, Michael","libertarian",FALSE,1793,1139824,20171015,NA
+2004,"Mississippi","MS",28,64,46,"US President","Peroutka, Michael","constitution party",FALSE,1758,1139824,20171015,NA
+2004,"Mississippi","MS",28,64,46,"US President","Calero, Roger","independent",FALSE,1599,1139824,20171015,NA
+2004,"Mississippi","MS",28,64,46,"US President","Cobb, David","green",FALSE,1073,1139824,20171015,NA
+2004,"Missouri","MO",29,43,34,"US President","Bush, George W.","republican",FALSE,1455713,2731364,20171015,NA
+2004,"Missouri","MO",29,43,34,"US President","Kerry, John","democrat",FALSE,1259171,2731364,20171015,NA
+2004,"Missouri","MO",29,43,34,"US President","Badnarik, Michael","libertarian",FALSE,9831,2731364,20171015,NA
+2004,"Missouri","MO",29,43,34,"US President","Peroutka, Michael","constitution party",FALSE,5355,2731364,20171015,NA
+2004,"Missouri","MO",29,43,34,"US President","Nader, Ralph","independent",TRUE,1294,2731364,20171015,NA
+2004,"Montana","MT",30,81,64,"US President","Bush, George W.","republican",FALSE,266063,450434,20171015,NA
+2004,"Montana","MT",30,81,64,"US President","Kerry, John","democrat",FALSE,173710,450434,20171015,NA
+2004,"Montana","MT",30,81,64,"US President","Nader, Ralph","independent",FALSE,6168,450434,20171015,NA
+2004,"Montana","MT",30,81,64,"US President","Peroutka, Michael","constitution party",FALSE,1764,450434,20171015,NA
+2004,"Montana","MT",30,81,64,"US President","Badnarik, Michael","libertarian",FALSE,1733,450434,20171015,NA
+2004,"Montana","MT",30,81,64,"US President","Cobb, David","green",FALSE,996,450434,20171015,NA
+2004,"Nebraska","NE",31,46,35,"US President","Bush, George W.","republican",FALSE,512814,778186,20171015,NA
+2004,"Nebraska","NE",31,46,35,"US President","Kerry, John","democrat",FALSE,254328,778186,20171015,NA
+2004,"Nebraska","NE",31,46,35,"US President","Nader, Ralph","reform party",FALSE,5780,778186,20171015,NA
+2004,"Nebraska","NE",31,46,35,"US President","Badnarik, Michael","libertarian",FALSE,2041,778186,20171015,NA
+2004,"Nebraska","NE",31,46,35,"US President","Other","nebraska party",FALSE,1314,778186,20171015,NA
+2004,"Nebraska","NE",31,46,35,"US President","Cobb, David","green",FALSE,978,778186,20171015,NA
+2004,"Nebraska","NE",31,46,35,"US President","Other","",TRUE,931,778186,20171015,NA
+2004,"Nevada","NV",32,88,65,"US President","Bush, George W.","republican",FALSE,418690,829587,20171015,NA
+2004,"Nevada","NV",32,88,65,"US President","Kerry, John","democrat",FALSE,397190,829587,20171015,NA
+2004,"Nevada","NV",32,88,65,"US President","Nader, Ralph","independent",FALSE,4838,829587,20171015,NA
+2004,"Nevada","NV",32,88,65,"US President","Other","",FALSE,3688,829587,20171015,NA
+2004,"Nevada","NV",32,88,65,"US President","Badnarik, Michael","libertarian",FALSE,3176,829587,20171015,NA
+2004,"Nevada","NV",32,88,65,"US President","Peroutka, Michael","independent american",FALSE,1152,829587,20171015,NA
+2004,"Nevada","NV",32,88,65,"US President","Cobb, David","green",FALSE,853,829587,20171015,NA
+2004,"New Hampshire","NH",33,12,4,"US President","Kerry, John","democrat",FALSE,340511,678287,20171015,NA
+2004,"New Hampshire","NH",33,12,4,"US President","Bush, George W.","republican",FALSE,331237,678287,20171015,NA
+2004,"New Hampshire","NH",33,12,4,"US President","Nader, Ralph","independent",FALSE,4479,678287,20171015,NA
+2004,"New Hampshire","NH",33,12,4,"US President","Other","",FALSE,1095,678287,20171015,NA
+2004,"New Hampshire","NH",33,12,4,"US President","Other","",TRUE,965,678287,20171015,NA
+2004,"New Jersey","NJ",34,22,12,"US President","Kerry, John","democrat",FALSE,1911430,3611691,20171015,NA
+2004,"New Jersey","NJ",34,22,12,"US President","Bush, George W.","republican",FALSE,1670003,3611691,20171015,NA
+2004,"New Jersey","NJ",34,22,12,"US President","Other","independent",FALSE,30258,3611691,20171015,NA
+2004,"New Mexico","NM",35,85,66,"US President","Bush, George W.","republican",FALSE,376930,756304,20171015,NA
+2004,"New Mexico","NM",35,85,66,"US President","Kerry, John","democrat",FALSE,370942,756304,20171015,NA
+2004,"New Mexico","NM",35,85,66,"US President","Nader, Ralph","independent",FALSE,4053,756304,20171015,NA
+2004,"New Mexico","NM",35,85,66,"US President","Badnarik, Michael","libertarian",FALSE,2382,756304,20171015,NA
+2004,"New Mexico","NM",35,85,66,"US President","Cobb, David","green",FALSE,1226,756304,20171015,NA
+2004,"New Mexico","NM",35,85,66,"US President","Peroutka, Michael","constitution party",FALSE,771,756304,20171015,NA
+2004,"New York","NY",36,21,13,"US President","Kerry, John","democrat",FALSE,4180755,7448266,20171015,NA
+2004,"New York","NY",36,21,13,"US President","Bush, George W.","republican",FALSE,2806993,7448266,20171015,NA
+2004,"New York","NY",36,21,13,"US President","Bush, George W.","conservative",FALSE,155574,7448266,20171015,NA
+2004,"New York","NY",36,21,13,"US President","Kerry, John","working families",FALSE,133525,7448266,20171015,NA
+2004,"New York","NY",36,21,13,"US President","Nader, Ralph","independence",FALSE,84247,7448266,20171015,NA
+2004,"New York","NY",36,21,13,"US President","Blank Vote/Scattering","",FALSE,57230,7448266,20171015,NA
+2004,"New York","NY",36,21,13,"US President","Nader, Ralph","peace and justice",FALSE,15626,7448266,20171015,NA
+2004,"New York","NY",36,21,13,"US President","Badnarik, Michael","libertarian",FALSE,11607,7448266,20171015,NA
+2004,"New York","NY",36,21,13,"US President","Calero, Roger","socialist workers",FALSE,2405,7448266,20171015,NA
+2004,"New York","NY",36,21,13,"US President","Other","",TRUE,304,7448266,20171015,NA
+2004,"North Carolina","NC",37,56,47,"US President","Bush, George W.","republican",FALSE,1961166,3501007,20171015,NA
+2004,"North Carolina","NC",37,56,47,"US President","Kerry, John","democrat",FALSE,1525849,3501007,20171015,NA
+2004,"North Carolina","NC",37,56,47,"US President","Badnarik, Michael","libertarian",FALSE,11731,3501007,20171015,NA
+2004,"North Carolina","NC",37,56,47,"US President","Other","unaffiliated",TRUE,2261,3501007,20171015,NA
+2004,"North Dakota","ND",38,44,36,"US President","Bush, George W.","republican",FALSE,196651,312833,20171015,NA
+2004,"North Dakota","ND",38,44,36,"US President","Kerry, John","democrat",FALSE,111052,312833,20171015,NA
+2004,"North Dakota","ND",38,44,36,"US President","Nader, Ralph","independent",FALSE,3756,312833,20171015,NA
+2004,"North Dakota","ND",38,44,36,"US President","Badnarik, Michael","libertarian",FALSE,851,312833,20171015,NA
+2004,"North Dakota","ND",38,44,36,"US President","Peroutka, Michael","constitution party",FALSE,514,312833,20171015,NA
+2004,"North Dakota","ND",38,44,36,"US President","Other","",TRUE,9,312833,20171015,NA
+2004,"Ohio","OH",39,31,24,"US President","Bush, George W.","republican",FALSE,2859764,5627903,20171015,NA
+2004,"Ohio","OH",39,31,24,"US President","Kerry, John","democrat",FALSE,2741165,5627903,20171015,NA
+2004,"Ohio","OH",39,31,24,"US President","Other","",FALSE,26616,5627903,20171015,NA
+2004,"Ohio","OH",39,31,24,"US President","Other","",TRUE,358,5627903,20171015,NA
+2004,"Oklahoma","OK",40,73,53,"US President","Bush, George W.","republican",FALSE,959792,1463758,20171015,NA
+2004,"Oklahoma","OK",40,73,53,"US President","Kerry, John","democrat",FALSE,503966,1463758,20171015,NA
+2004,"Oregon","OR",41,92,72,"US President","Kerry, John","democrat",FALSE,943163,1836782,20171015,NA
+2004,"Oregon","OR",41,92,72,"US President","Bush, George W.","republican",FALSE,866831,1836782,20171015,NA
+2004,"Oregon","OR",41,92,72,"US President","Other","",FALSE,8956,1836782,20171015,NA
+2004,"Oregon","OR",41,92,72,"US President","Badnarik, Michael","libertarian",FALSE,7260,1836782,20171015,NA
+2004,"Oregon","OR",41,92,72,"US President","Cobb, David","pacific green",FALSE,5315,1836782,20171015,NA
+2004,"Oregon","OR",41,92,72,"US President","Peroutka, Michael","constitution party",FALSE,5257,1836782,20171015,NA
+2004,"Pennsylvania","PA",42,23,14,"US President","Kerry, John","democrat",FALSE,2938095,5769590,20171015,NA
+2004,"Pennsylvania","PA",42,23,14,"US President","Bush, George W.","republican",FALSE,2793847,5769590,20171015,NA
+2004,"Pennsylvania","PA",42,23,14,"US President","Badnarik, Michael","libertarian",FALSE,21185,5769590,20171015,NA
+2004,"Pennsylvania","PA",42,23,14,"US President","Cobb, David","green",FALSE,6319,5769590,20171015,NA
+2004,"Pennsylvania","PA",42,23,14,"US President","Peroutka, Michael","constitution party",FALSE,6318,5769590,20171015,NA
+2004,"Pennsylvania","PA",42,23,14,"US President","Independent Party Candidate,","independent",TRUE,2656,5769590,20171015,NA
+2004,"Pennsylvania","PA",42,23,14,"US President","Blank Vote/Scattering","",FALSE,1170,5769590,20171015,NA
+2004,"Rhode Island","RI",44,15,5,"US President","Kerry, John","democrat",FALSE,259760,437134,20171015,NA
+2004,"Rhode Island","RI",44,15,5,"US President","Bush, George W.","republican",FALSE,169046,437134,20171015,NA
+2004,"Rhode Island","RI",44,15,5,"US President","Nader, Ralph","reform party",FALSE,4651,437134,20171015,NA
+2004,"Rhode Island","RI",44,15,5,"US President","Cobb, David","green",FALSE,1333,437134,20171015,NA
+2004,"Rhode Island","RI",44,15,5,"US President","Badnarik, Michael","libertarian",FALSE,907,437134,20171015,NA
+2004,"Rhode Island","RI",44,15,5,"US President","Nonpartisan","nonpartisan",FALSE,845,437134,20171015,NA
+2004,"Rhode Island","RI",44,15,5,"US President","Peroutka, Michael","constitution party",FALSE,339,437134,20171015,NA
+2004,"Rhode Island","RI",44,15,5,"US President","Workers World","workers world",FALSE,253,437134,20171015,NA
+2004,"South Carolina","SC",45,57,48,"US President","Bush, George W.","republican",FALSE,937974,1617700,20171015,NA
+2004,"South Carolina","SC",45,57,48,"US President","Kerry, John","democrat",FALSE,661669,1617700,20171015,NA
+2004,"South Carolina","SC",45,57,48,"US President","Nader, Ralph","independence",FALSE,5520,1617700,20171015,NA
+2004,"South Carolina","SC",45,57,48,"US President","Peroutka, Michael","constitution party",FALSE,5317,1617700,20171015,NA
+2004,"South Carolina","SC",45,57,48,"US President","Badnarik, Michael","libertarian",FALSE,3608,1617700,20171015,NA
+2004,"South Carolina","SC",45,57,48,"US President","Brown, Walt","united citizens",FALSE,2124,1617700,20171015,NA
+2004,"South Carolina","SC",45,57,48,"US President","Cobb, David","green",FALSE,1488,1617700,20171015,NA
+2004,"South Dakota","SD",46,45,37,"US President","Bush, George W.","republican",FALSE,232584,388215,20171015,NA
+2004,"South Dakota","SD",46,45,37,"US President","Kerry, John","democrat",FALSE,149244,388215,20171015,NA
+2004,"South Dakota","SD",46,45,37,"US President","Nader, Ralph","independent",FALSE,4320,388215,20171015,NA
+2004,"South Dakota","SD",46,45,37,"US President","Peroutka, Michael","constitution party",FALSE,1103,388215,20171015,NA
+2004,"South Dakota","SD",46,45,37,"US President","Badnarik, Michael","libertarian",FALSE,964,388215,20171015,NA
+2004,"Tennessee","TN",47,62,54,"US President","Bush, George W.","republican",FALSE,1384375,2437319,20171015,NA
+2004,"Tennessee","TN",47,62,54,"US President","Kerry, John","democrat",FALSE,1036477,2437319,20171015,NA
+2004,"Tennessee","TN",47,62,54,"US President","Other","independent",FALSE,16428,2437319,20171015,NA
+2004,"Tennessee","TN",47,62,54,"US President","Other","",TRUE,39,2437319,20171015,NA
+2004,"Texas","TX",48,74,49,"US President","Bush, George W.","republican",FALSE,4526917,7410749,20171015,NA
+2004,"Texas","TX",48,74,49,"US President","Kerry, John","democrat",FALSE,2832704,7410749,20171015,NA
+2004,"Texas","TX",48,74,49,"US President","Badnarik, Michael","libertarian",FALSE,38787,7410749,20171015,NA
+2004,"Texas","TX",48,74,49,"US President","Other","",TRUE,12341,7410749,20171015,NA
+2004,"Utah","UT",49,87,67,"US President","Bush, George W.","republican",FALSE,663742,927844,20171015,NA
+2004,"Utah","UT",49,87,67,"US President","Kerry, John","democrat",FALSE,241199,927844,20171015,NA
+2004,"Utah","UT",49,87,67,"US President","Nader, Ralph","unaffiliated",FALSE,11305,927844,20171015,NA
+2004,"Utah","UT",49,87,67,"US President","Peroutka, Michael","constitution party",FALSE,6841,927844,20171015,NA
+2004,"Utah","UT",49,87,67,"US President","Badnarik, Michael","libertarian",FALSE,3375,927844,20171015,NA
+2004,"Utah","UT",49,87,67,"US President","Jay, Charles","personal choice",FALSE,946,927844,20171015,NA
+2004,"Utah","UT",49,87,67,"US President","Calero, Roger","socialist workers",FALSE,393,927844,20171015,NA
+2004,"Utah","UT",49,87,67,"US President","Other","",TRUE,43,927844,20171015,NA
+2004,"Vermont","VT",50,13,6,"US President","Kerry, John","democrat",FALSE,184067,312309,20171015,NA
+2004,"Vermont","VT",50,13,6,"US President","Bush, George W.","republican",FALSE,121180,312309,20171015,NA
+2004,"Vermont","VT",50,13,6,"US President","Nader, Ralph","independent",FALSE,4494,312309,20171015,NA
+2004,"Vermont","VT",50,13,6,"US President","Badnarik, Michael","libertarian",FALSE,1102,312309,20171015,NA
+2004,"Vermont","VT",50,13,6,"US President","Other","",TRUE,957,312309,20171015,NA
+2004,"Vermont","VT",50,13,6,"US President","Parker, John","liberty union party",FALSE,265,312309,20171015,NA
+2004,"Vermont","VT",50,13,6,"US President","Calero, Roger","socialist workers",FALSE,244,312309,20171015,NA
+2004,"Virginia","VA",51,54,40,"US President","Bush, George W.","republican",FALSE,1716959,3195415,20171015,NA
+2004,"Virginia","VA",51,54,40,"US President","Kerry, John","democrat",FALSE,1454742,3195415,20171015,NA
+2004,"Virginia","VA",51,54,40,"US President","Badnarik, Michael","libertarian",FALSE,11032,3195415,20171015,NA
+2004,"Virginia","VA",51,54,40,"US President","Peroutka, Michael","constitution party",FALSE,10161,3195415,20171015,NA
+2004,"Virginia","VA",51,54,40,"US President","Other","",TRUE,2521,3195415,20171015,NA
+2004,"Washington","WA",53,91,73,"US President","Kerry, John","democrat",FALSE,1510201,2859084,20171015,NA
+2004,"Washington","WA",53,91,73,"US President","Bush, George W.","republican",FALSE,1304894,2859084,20171015,NA
+2004,"Washington","WA",53,91,73,"US President","Nader, Ralph","independent",FALSE,23283,2859084,20171015,NA
+2004,"Washington","WA",53,91,73,"US President","Badnarik, Michael","libertarian",FALSE,11955,2859084,20171015,NA
+2004,"Washington","WA",53,91,73,"US President","Peroutka, Michael","constitution party",FALSE,3922,2859084,20171015,NA
+2004,"Washington","WA",53,91,73,"US President","Cobb, David","green",FALSE,2974,2859084,20171015,NA
+2004,"Washington","WA",53,91,73,"US President","Parker, John","workers world",FALSE,1077,2859084,20171015,NA
+2004,"Washington","WA",53,91,73,"US President","Calero, Roger","socialist workers",FALSE,547,2859084,20171015,NA
+2004,"Washington","WA",53,91,73,"US President","Van Auken, Bill","socialist equality party",FALSE,231,2859084,20171015,NA
+2004,"West Virginia","WV",54,55,56,"US President","Bush, George W.","republican",FALSE,423778,755792,20171015,NA
+2004,"West Virginia","WV",54,55,56,"US President","Kerry, John","democrat",FALSE,326541,755792,20171015,NA
+2004,"West Virginia","WV",54,55,56,"US President","Nader, Ralph","independent",FALSE,4063,755792,20171015,NA
+2004,"West Virginia","WV",54,55,56,"US President","Badnarik, Michael","libertarian",FALSE,1405,755792,20171015,NA
+2004,"West Virginia","WV",54,55,56,"US President","Cobb, David","",TRUE,5,755792,20171015,NA
+2004,"Wisconsin","WI",55,35,25,"US President","Kerry, John","democrat",FALSE,1489504,2997007,20171015,NA
+2004,"Wisconsin","WI",55,35,25,"US President","Bush, George W.","republican",FALSE,1478120,2997007,20171015,NA
+2004,"Wisconsin","WI",55,35,25,"US President","Nader, Ralph","independent",FALSE,17272,2997007,20171015,NA
+2004,"Wisconsin","WI",55,35,25,"US President","Badnarik, Michael","libertarian",FALSE,6464,2997007,20171015,NA
+2004,"Wisconsin","WI",55,35,25,"US President","Blank Vote/Scattering","",FALSE,2986,2997007,20171015,NA
+2004,"Wisconsin","WI",55,35,25,"US President","Cobb, David","wisconsin green",FALSE,2661,2997007,20171015,NA
+2004,"Wyoming","WY",56,83,68,"US President","Bush, George W.","republican",FALSE,167629,243861,20171015,NA
+2004,"Wyoming","WY",56,83,68,"US President","Kerry, John","democrat",FALSE,70776,243861,20171015,NA
+2004,"Wyoming","WY",56,83,68,"US President","Nader, Ralph","independent",FALSE,3372,243861,20171015,NA
+2004,"Wyoming","WY",56,83,68,"US President","Badnarik, Michael","libertarian",FALSE,1171,243861,20171015,NA
+2004,"Wyoming","WY",56,83,68,"US President","Other","",TRUE,480,243861,20171015,NA
+2004,"Wyoming","WY",56,83,68,"US President","Other","",FALSE,433,243861,20171015,NA
+2008,"Alabama","AL",1,63,41,"US President","McCain, John","republican",FALSE,1266546,2099819,20171015,NA
+2008,"Alabama","AL",1,63,41,"US President","Obama, Barack H.","democrat",FALSE,813479,2099819,20171015,NA
+2008,"Alabama","AL",1,63,41,"US President","","independent",FALSE,16089,2099819,20171015,NA
+2008,"Alabama","AL",1,63,41,"US President","","",TRUE,3705,2099819,20171015,NA
+2008,"Alaska","AK",2,94,81,"US President","McCain, John","republican",FALSE,193841,326197,20171015,NA
+2008,"Alaska","AK",2,94,81,"US President","Obama, Barack H.","democrat",FALSE,123594,326197,20171015,NA
+2008,"Alaska","AK",2,94,81,"US President","Nader, Ralph","independent",FALSE,3783,326197,20171015,NA
+2008,"Alaska","AK",2,94,81,"US President","","",TRUE,1730,326197,20171015,NA
+2008,"Alaska","AK",2,94,81,"US President","Baldwin, Charles """"Chuck""""","alaskan independence party",FALSE,1660,326197,20171015,NA
+2008,"Alaska","AK",2,94,81,"US President","Barr, Bob","libertarian",FALSE,1589,326197,20171015,NA
+2008,"Arizona","AZ",4,86,61,"US President","McCain, John","republican",FALSE,1230111,2293475,20171015,NA
+2008,"Arizona","AZ",4,86,61,"US President","Obama, Barack H.","democrat",FALSE,1034707,2293475,20171015,NA
+2008,"Arizona","AZ",4,86,61,"US President","Barr, Bob","libertarian",FALSE,12555,2293475,20171015,NA
+2008,"Arizona","AZ",4,86,61,"US President","Nader, Ralph","independent",FALSE,11301,2293475,20171015,NA
+2008,"Arizona","AZ",4,86,61,"US President","McKinney, Cynthia","green",FALSE,3406,2293475,20171015,NA
+2008,"Arizona","AZ",4,86,61,"US President","","",TRUE,1395,2293475,20171015,NA
+2008,"Arkansas","AR",5,71,42,"US President","McCain, John","republican",FALSE,638017,1086617,20171015,NA
+2008,"Arkansas","AR",5,71,42,"US President","Obama, Barack H.","democrat",FALSE,422310,1086617,20171015,NA
+2008,"Arkansas","AR",5,71,42,"US President","Nader, Ralph","independent",FALSE,12882,1086617,20171015,NA
+2008,"Arkansas","AR",5,71,42,"US President","Barr, Bob","libertarian",FALSE,4776,1086617,20171015,NA
+2008,"Arkansas","AR",5,71,42,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,4023,1086617,20171015,NA
+2008,"Arkansas","AR",5,71,42,"US President","McKinney, Cynthia","green",FALSE,3470,1086617,20171015,NA
+2008,"Arkansas","AR",5,71,42,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,1139,1086617,20171015,NA
+2008,"California","CA",6,93,71,"US President","Obama, Barack H.","democrat",FALSE,8274473,13561900,20171015,NA
+2008,"California","CA",6,93,71,"US President","McCain, John","republican",FALSE,5011781,13561900,20171015,NA
+2008,"California","CA",6,93,71,"US President","Nader, Ralph","peace & freedom",FALSE,108381,13561900,20171015,NA
+2008,"California","CA",6,93,71,"US President","Barr, Bob","libertarian",FALSE,67582,13561900,20171015,NA
+2008,"California","CA",6,93,71,"US President","Keyes, Alan","american independent party",FALSE,40673,13561900,20171015,NA
+2008,"California","CA",6,93,71,"US President","McKinney, Cynthia","green",FALSE,38774,13561900,20171015,NA
+2008,"California","CA",6,93,71,"US President","","independent",TRUE,20236,13561900,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","Obama, Barack H.","democrat",FALSE,1288576,2401361,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","McCain, John","republican",FALSE,1073589,2401361,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","Nader, Ralph","independent",FALSE,13350,2401361,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","Barr, Bob","libertarian",FALSE,10897,2401361,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,6233,2401361,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","Keyes, Alan","america's independent party",FALSE,3051,2401361,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","McKinney, Cynthia","green",FALSE,2822,2401361,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","McEnulty, Frank","unaffiliated",FALSE,828,2401361,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","Jay, Charles","boston tea party",FALSE,598,2401361,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","Allen, Jonathan","heartquake '08",FALSE,348,2401361,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","Stevens, Thomas R.","objectivist party",FALSE,336,2401361,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","Moore, Brian","socialist",FALSE,226,2401361,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,158,2401361,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","Harris, James","socialist workers",FALSE,154,2401361,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","Lyttle, Bradford","u.s. pacifist party",FALSE,110,2401361,20171015,NA
+2008,"Colorado","CO",8,84,62,"US President","Amondson, Gene","prohibition",FALSE,85,2401361,20171015,NA
+2008,"Connecticut","CT",9,16,1,"US President","Obama, Barack H.","democrat",FALSE,997772,1646792,20171015,NA
+2008,"Connecticut","CT",9,16,1,"US President","McCain, John","republican",FALSE,629428,1646792,20171015,NA
+2008,"Connecticut","CT",9,16,1,"US President","Nader, Ralph","independent",FALSE,19162,1646792,20171015,NA
+2008,"Connecticut","CT",9,16,1,"US President","","",TRUE,430,1646792,20171015,NA
+2008,"Delaware","DE",10,51,11,"US President","Obama, Barack H.","democrat",FALSE,255459,412412,20171015,NA
+2008,"Delaware","DE",10,51,11,"US President","McCain, John","republican",FALSE,152374,412412,20171015,NA
+2008,"Delaware","DE",10,51,11,"US President","Nader, Ralph","independent",FALSE,2401,412412,20171015,NA
+2008,"Delaware","DE",10,51,11,"US President","Barr, Bob","libertarian",FALSE,1109,412412,20171015,NA
+2008,"Delaware","DE",10,51,11,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,626,412412,20171015,NA
+2008,"Delaware","DE",10,51,11,"US President","McKinney, Cynthia","green",FALSE,385,412412,20171015,NA
+2008,"Delaware","DE",10,51,11,"US President","Calero, Roger","socialist workers",FALSE,58,412412,20171015,NA
+2008,"District of Columbia","DC",11,53,55,"US President","Obama, Barack H.","democrat",FALSE,245800,265853,20171015,NA
+2008,"District of Columbia","DC",11,53,55,"US President","McCain, John","republican",FALSE,17367,265853,20171015,NA
+2008,"District of Columbia","DC",11,53,55,"US President","","",TRUE,1138,265853,20171015,NA
+2008,"District of Columbia","DC",11,53,55,"US President","Nader, Ralph","independent",FALSE,958,265853,20171015,NA
+2008,"District of Columbia","DC",11,53,55,"US President","McKinney, Cynthia","green",FALSE,590,265853,20171015,NA
+2008,"Florida","FL",12,59,43,"US President","Obama, Barack H.","democrat",FALSE,4282074,8390744,20171015,NA
+2008,"Florida","FL",12,59,43,"US President","McCain, John","republican",FALSE,4045624,8390744,20171015,NA
+2008,"Florida","FL",12,59,43,"US President","Nader, Ralph","ecology party of florida",FALSE,28124,8390744,20171015,NA
+2008,"Florida","FL",12,59,43,"US President","Barr, Bob","libertarian",FALSE,17218,8390744,20171015,NA
+2008,"Florida","FL",12,59,43,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,7915,8390744,20171015,NA
+2008,"Florida","FL",12,59,43,"US President","McKinney, Cynthia","green",FALSE,2887,8390744,20171015,NA
+2008,"Florida","FL",12,59,43,"US President","Keyes, Alan","america's independent party",FALSE,2550,8390744,20171015,NA
+2008,"Florida","FL",12,59,43,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,1516,8390744,20171015,NA
+2008,"Florida","FL",12,59,43,"US President","Jay, Charles","boston tea party",FALSE,795,8390744,20171015,NA
+2008,"Florida","FL",12,59,43,"US President","Calero, Roger","socialist workers",FALSE,533,8390744,20171015,NA
+2008,"Florida","FL",12,59,43,"US President","Stevens, Thomas R.","objectivist party",FALSE,419,8390744,20171015,NA
+2008,"Florida","FL",12,59,43,"US President","Moore, Brian","socialist",FALSE,405,8390744,20171015,NA
+2008,"Florida","FL",12,59,43,"US President","","",TRUE,391,8390744,20171015,NA
+2008,"Florida","FL",12,59,43,"US President","Amondson, Gene","prohibition",FALSE,293,8390744,20171015,NA
+2008,"Georgia","GA",13,58,44,"US President","McCain, John","republican",FALSE,2048759,3924486,20171015,NA
+2008,"Georgia","GA",13,58,44,"US President","Obama, Barack H.","democrat",FALSE,1844123,3924486,20171015,NA
+2008,"Georgia","GA",13,58,44,"US President","Barr, Bob","libertarian",FALSE,28731,3924486,20171015,NA
+2008,"Georgia","GA",13,58,44,"US President","","",TRUE,1715,3924486,20171015,NA
+2008,"Georgia","GA",13,58,44,"US President","","independent",TRUE,1158,3924486,20171015,NA
+2008,"Hawaii","HI",15,95,82,"US President","Obama, Barack H.","democrat",FALSE,325871,456064,20171015,NA
+2008,"Hawaii","HI",15,95,82,"US President","McCain, John","republican",FALSE,120566,456064,20171015,NA
+2008,"Hawaii","HI",15,95,82,"US President","Nader, Ralph","independent",FALSE,3825,456064,20171015,NA
+2008,"Hawaii","HI",15,95,82,"US President","Blank Vote","",FALSE,2193,456064,20171015,NA
+2008,"Hawaii","HI",15,95,82,"US President","Barr, Bob","libertarian",FALSE,1314,456064,20171015,NA
+2008,"Hawaii","HI",15,95,82,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,1013,456064,20171015,NA
+2008,"Hawaii","HI",15,95,82,"US President","McKinney, Cynthia","green",FALSE,979,456064,20171015,NA
+2008,"Hawaii","HI",15,95,82,"US President","Over Vote","",FALSE,303,456064,20171015,NA
+2008,"Idaho","ID",16,82,63,"US President","McCain, John","republican",FALSE,403012,655122,20171015,NA
+2008,"Idaho","ID",16,82,63,"US President","Obama, Barack H.","democrat",FALSE,236440,655122,20171015,NA
+2008,"Idaho","ID",16,82,63,"US President","Nader, Ralph","independent",FALSE,7175,655122,20171015,NA
+2008,"Idaho","ID",16,82,63,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,4747,655122,20171015,NA
+2008,"Idaho","ID",16,82,63,"US President","Barr, Bob","libertarian",FALSE,3658,655122,20171015,NA
+2008,"Idaho","ID",16,82,63,"US President","","",TRUE,90,655122,20171015,NA
+2008,"Illinois","IL",17,33,21,"US President","Obama, Barack H.","democrat",FALSE,3419348,5522371,20171015,NA
+2008,"Illinois","IL",17,33,21,"US President","McCain, John","republican",FALSE,2031179,5522371,20171015,NA
+2008,"Illinois","IL",17,33,21,"US President","Nader, Ralph","independent",FALSE,30948,5522371,20171015,NA
+2008,"Illinois","IL",17,33,21,"US President","Barr, Bob","libertarian",FALSE,19642,5522371,20171015,NA
+2008,"Illinois","IL",17,33,21,"US President","McKinney, Cynthia","green",FALSE,11838,5522371,20171015,NA
+2008,"Illinois","IL",17,33,21,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,8256,5522371,20171015,NA
+2008,"Illinois","IL",17,33,21,"US President","","new",FALSE,1149,5522371,20171015,NA
+2008,"Illinois","IL",17,33,21,"US President","","",TRUE,11,5522371,20171015,NA
+2008,"Indiana","IN",18,32,22,"US President","Obama, Barack H.","democrat",FALSE,1374039,2751054,20171015,NA
+2008,"Indiana","IN",18,32,22,"US President","McCain, John","republican",FALSE,1345648,2751054,20171015,NA
+2008,"Indiana","IN",18,32,22,"US President","Barr, Bob","libertarian",FALSE,29257,2751054,20171015,NA
+2008,"Indiana","IN",18,32,22,"US President","","",TRUE,1201,2751054,20171015,NA
+2008,"Indiana","IN",18,32,22,"US President","Nader, Ralph","independent",TRUE,909,2751054,20171015,NA
+2008,"Iowa","IA",19,42,31,"US President","Obama, Barack H.","democrat",FALSE,828940,1537123,20171015,NA
+2008,"Iowa","IA",19,42,31,"US President","McCain, John","republican",FALSE,682379,1537123,20171015,NA
+2008,"Iowa","IA",19,42,31,"US President","Nader, Ralph","peace & freedom",FALSE,8014,1537123,20171015,NA
+2008,"Iowa","IA",19,42,31,"US President","","",TRUE,6737,1537123,20171015,NA
+2008,"Iowa","IA",19,42,31,"US President","Barr, Bob","libertarian",FALSE,4590,1537123,20171015,NA
+2008,"Iowa","IA",19,42,31,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,4445,1537123,20171015,NA
+2008,"Iowa","IA",19,42,31,"US President","McKinney, Cynthia","green",FALSE,1423,1537123,20171015,NA
+2008,"Iowa","IA",19,42,31,"US President","Harris, James","socialist workers",FALSE,292,1537123,20171015,NA
+2008,"Iowa","IA",19,42,31,"US President","Moore, Brian","socialist",FALSE,182,1537123,20171015,NA
+2008,"Iowa","IA",19,42,31,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,121,1537123,20171015,NA
+2008,"Kansas","KS",20,47,32,"US President","McCain, John","republican",FALSE,699655,1235872,20171015,NA
+2008,"Kansas","KS",20,47,32,"US President","Obama, Barack H.","democrat",FALSE,514765,1235872,20171015,NA
+2008,"Kansas","KS",20,47,32,"US President","Nader, Ralph","independent",FALSE,10598,1235872,20171015,NA
+2008,"Kansas","KS",20,47,32,"US President","Barr, Bob","libertarian",FALSE,6706,1235872,20171015,NA
+2008,"Kansas","KS",20,47,32,"US President","Baldwin, Charles """"Chuck""""","reform party",FALSE,4148,1235872,20171015,NA
+2008,"Kentucky","KY",21,61,51,"US President","McCain, John","republican",FALSE,1048462,1826620,20171015,NA
+2008,"Kentucky","KY",21,61,51,"US President","Obama, Barack H.","democrat",FALSE,751985,1826620,20171015,NA
+2008,"Kentucky","KY",21,61,51,"US President","Nader, Ralph","independent",FALSE,15378,1826620,20171015,NA
+2008,"Kentucky","KY",21,61,51,"US President","Barr, Bob","libertarian",FALSE,5989,1826620,20171015,NA
+2008,"Kentucky","KY",21,61,51,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,4694,1826620,20171015,NA
+2008,"Kentucky","KY",21,61,51,"US President","","",TRUE,112,1826620,20171015,NA
+2008,"Louisiana","LA",22,72,45,"US President","McCain, John","republican",FALSE,1148275,1960761,20171015,NA
+2008,"Louisiana","LA",22,72,45,"US President","Obama, Barack H.","democrat",FALSE,782989,1960761,20171015,NA
+2008,"Louisiana","LA",22,72,45,"US President","Paul, Ronald """"Ron""""","louisiana taxpayers party",FALSE,9368,1960761,20171015,NA
+2008,"Louisiana","LA",22,72,45,"US President","McKinney, Cynthia","green",FALSE,9187,1960761,20171015,NA
+2008,"Louisiana","LA",22,72,45,"US President","Nader, Ralph","independent",FALSE,6997,1960761,20171015,NA
+2008,"Louisiana","LA",22,72,45,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,2581,1960761,20171015,NA
+2008,"Louisiana","LA",22,72,45,"US President","Harris, James","socialist workers",FALSE,735,1960761,20171015,NA
+2008,"Louisiana","LA",22,72,45,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,354,1960761,20171015,NA
+2008,"Louisiana","LA",22,72,45,"US President","Amondson, Gene","prohibition",FALSE,275,1960761,20171015,NA
+2008,"Maine","ME",23,11,2,"US President","Obama, Barack H.","democrat",FALSE,421923,731163,20171015,NA
+2008,"Maine","ME",23,11,2,"US President","McCain, John","republican",FALSE,295273,731163,20171015,NA
+2008,"Maine","ME",23,11,2,"US President","Nader, Ralph","independent",FALSE,10636,731163,20171015,NA
+2008,"Maine","ME",23,11,2,"US President","McKinney, Cynthia","green",FALSE,2900,731163,20171015,NA
+2008,"Maine","ME",23,11,2,"US President","Other","",FALSE,431,731163,20171015,NA
+2008,"Maryland","MD",24,52,52,"US President","Obama, Barack H.","democrat",FALSE,1629467,2631596,20171015,NA
+2008,"Maryland","MD",24,52,52,"US President","McCain, John","republican",FALSE,959862,2631596,20171015,NA
+2008,"Maryland","MD",24,52,52,"US President","Nader, Ralph","independent",FALSE,14713,2631596,20171015,NA
+2008,"Maryland","MD",24,52,52,"US President","Barr, Bob","libertarian",FALSE,9842,2631596,20171015,NA
+2008,"Maryland","MD",24,52,52,"US President","","",TRUE,9205,2631596,20171015,NA
+2008,"Maryland","MD",24,52,52,"US President","McKinney, Cynthia","green",FALSE,4747,2631596,20171015,NA
+2008,"Maryland","MD",24,52,52,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,3760,2631596,20171015,NA
+2008,"Massachusetts","MA",25,14,3,"US President","Obama, Barack H.","democrat",FALSE,1904097,3102995,20171015,NA
+2008,"Massachusetts","MA",25,14,3,"US President","McCain, John","republican",FALSE,1108854,3102995,20171015,NA
+2008,"Massachusetts","MA",25,14,3,"US President","Nader, Ralph","independent",FALSE,28841,3102995,20171015,NA
+2008,"Massachusetts","MA",25,14,3,"US President","Blank Vote/Scattering","",FALSE,22010,3102995,20171015,NA
+2008,"Massachusetts","MA",25,14,3,"US President","Other","",FALSE,14483,3102995,20171015,NA
+2008,"Massachusetts","MA",25,14,3,"US President","Barr, Bob","libertarian",FALSE,13189,3102995,20171015,NA
+2008,"Massachusetts","MA",25,14,3,"US President","McKinney, Cynthia","green",FALSE,6550,3102995,20171015,NA
+2008,"Massachusetts","MA",25,14,3,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,4971,3102995,20171015,NA
+2008,"Michigan","MI",26,34,23,"US President","Obama, Barack H.","democrat",FALSE,2872579,5001596,20171015,NA
+2008,"Michigan","MI",26,34,23,"US President","McCain, John","republican",FALSE,2048639,5001596,20171015,NA
+2008,"Michigan","MI",26,34,23,"US President","Nader, Ralph","natural law",FALSE,33085,5001596,20171015,NA
+2008,"Michigan","MI",26,34,23,"US President","Barr, Bob","libertarian",FALSE,23716,5001596,20171015,NA
+2008,"Michigan","MI",26,34,23,"US President","Baldwin, Charles """"Chuck""""","u.s. taxpayers party",FALSE,14685,5001596,20171015,NA
+2008,"Michigan","MI",26,34,23,"US President","McKinney, Cynthia","green",FALSE,8892,5001596,20171015,NA
+2008,"Minnesota","MN",27,41,33,"US President","Obama, Barack H.","democrat",FALSE,1573354,2910369,20171015,NA
+2008,"Minnesota","MN",27,41,33,"US President","McCain, John","republican",FALSE,1275409,2910369,20171015,NA
+2008,"Minnesota","MN",27,41,33,"US President","Nader, Ralph","independent",FALSE,30152,2910369,20171015,NA
+2008,"Minnesota","MN",27,41,33,"US President","","",TRUE,9529,2910369,20171015,NA
+2008,"Minnesota","MN",27,41,33,"US President","Barr, Bob","libertarian",FALSE,9174,2910369,20171015,NA
+2008,"Minnesota","MN",27,41,33,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,6787,2910369,20171015,NA
+2008,"Minnesota","MN",27,41,33,"US President","McKinney, Cynthia","green",FALSE,5174,2910369,20171015,NA
+2008,"Minnesota","MN",27,41,33,"US President","Calero, Roger","socialist workers",FALSE,790,2910369,20171015,NA
+2008,"Mississippi","MS",28,64,46,"US President","McCain, John","republican",FALSE,724597,1289865,20171015,NA
+2008,"Mississippi","MS",28,64,46,"US President","Obama, Barack H.","democrat",FALSE,554662,1289865,20171015,NA
+2008,"Mississippi","MS",28,64,46,"US President","Nader, Ralph","independent",FALSE,4011,1289865,20171015,NA
+2008,"Mississippi","MS",28,64,46,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,2551,1289865,20171015,NA
+2008,"Mississippi","MS",28,64,46,"US President","Barr, Bob","libertarian",FALSE,2529,1289865,20171015,NA
+2008,"Mississippi","MS",28,64,46,"US President","McKinney, Cynthia","green",FALSE,1034,1289865,20171015,NA
+2008,"Mississippi","MS",28,64,46,"US President","Weill, Ted","reform party",FALSE,481,1289865,20171015,NA
+2008,"Missouri","MO",29,43,34,"US President","McCain, John","republican",FALSE,1445814,2925205,20171015,NA
+2008,"Missouri","MO",29,43,34,"US President","Obama, Barack H.","democrat",FALSE,1441911,2925205,20171015,NA
+2008,"Missouri","MO",29,43,34,"US President","Nader, Ralph","independent",FALSE,17813,2925205,20171015,NA
+2008,"Missouri","MO",29,43,34,"US President","Barr, Bob","libertarian",FALSE,11386,2925205,20171015,NA
+2008,"Missouri","MO",29,43,34,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,8201,2925205,20171015,NA
+2008,"Missouri","MO",29,43,34,"US President","McKinney, Cynthia","",TRUE,80,2925205,20171015,NA
+2008,"Montana","MT",30,81,64,"US President","McCain, John","republican",FALSE,242763,490109,20171015,NA
+2008,"Montana","MT",30,81,64,"US President","Obama, Barack H.","democrat",FALSE,231667,490109,20171015,NA
+2008,"Montana","MT",30,81,64,"US President","Paul, Ronald """"Ron""""","constitution party",FALSE,10638,490109,20171015,NA
+2008,"Montana","MT",30,81,64,"US President","Nader, Ralph","independent",FALSE,3686,490109,20171015,NA
+2008,"Montana","MT",30,81,64,"US President","Barr, Bob","libertarian",FALSE,1355,490109,20171015,NA
+2008,"Nebraska","NE",31,46,35,"US President","McCain, John","republican",FALSE,452979,801281,20171015,NA
+2008,"Nebraska","NE",31,46,35,"US President","Obama, Barack H.","democrat",FALSE,333319,801281,20171015,NA
+2008,"Nebraska","NE",31,46,35,"US President","Nader, Ralph","independent",FALSE,5406,801281,20171015,NA
+2008,"Nebraska","NE",31,46,35,"US President","Baldwin, Charles """"Chuck""""","nebraska party",FALSE,2972,801281,20171015,NA
+2008,"Nebraska","NE",31,46,35,"US President","","",TRUE,2837,801281,20171015,NA
+2008,"Nebraska","NE",31,46,35,"US President","Barr, Bob","libertarian",FALSE,2740,801281,20171015,NA
+2008,"Nebraska","NE",31,46,35,"US President","McKinney, Cynthia","green",FALSE,1028,801281,20171015,NA
+2008,"Nevada","NV",32,88,65,"US President","Obama, Barack H.","democrat",FALSE,533736,967848,20171015,NA
+2008,"Nevada","NV",32,88,65,"US President","McCain, John","republican",FALSE,412827,967848,20171015,NA
+2008,"Nevada","NV",32,88,65,"US President","None Of These Candidates","",FALSE,6267,967848,20171015,NA
+2008,"Nevada","NV",32,88,65,"US President","Nader, Ralph","independent",FALSE,6150,967848,20171015,NA
+2008,"Nevada","NV",32,88,65,"US President","Barr, Bob","libertarian",FALSE,4263,967848,20171015,NA
+2008,"Nevada","NV",32,88,65,"US President","Baldwin, Charles """"Chuck""""","independent american",FALSE,3194,967848,20171015,NA
+2008,"Nevada","NV",32,88,65,"US President","McKinney, Cynthia","green",FALSE,1411,967848,20171015,NA
+2008,"New Hampshire","NH",33,12,4,"US President","Obama, Barack H.","democrat",FALSE,384826,710970,20171015,NA
+2008,"New Hampshire","NH",33,12,4,"US President","McCain, John","republican",FALSE,316534,710970,20171015,NA
+2008,"New Hampshire","NH",33,12,4,"US President","Nader, Ralph","independent",FALSE,3503,710970,20171015,NA
+2008,"New Hampshire","NH",33,12,4,"US President","","",TRUE,3359,710970,20171015,NA
+2008,"New Hampshire","NH",33,12,4,"US President","Barr, Bob","libertarian",FALSE,2748,710970,20171015,NA
+2008,"New Jersey","NJ",34,22,12,"US President","Obama, Barack H.","democrat",FALSE,2215422,3868237,20171015,NA
+2008,"New Jersey","NJ",34,22,12,"US President","McCain, John","republican",FALSE,1613207,3868237,20171015,NA
+2008,"New Jersey","NJ",34,22,12,"US President","Nader, Ralph","independent",FALSE,21298,3868237,20171015,NA
+2008,"New Jersey","NJ",34,22,12,"US President","Barr, Bob","libertarian",FALSE,8441,3868237,20171015,NA
+2008,"New Jersey","NJ",34,22,12,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,3956,3868237,20171015,NA
+2008,"New Jersey","NJ",34,22,12,"US President","McKinney, Cynthia","green",FALSE,3636,3868237,20171015,NA
+2008,"New Jersey","NJ",34,22,12,"US President","Moore, Brian","socialist",FALSE,699,3868237,20171015,NA
+2008,"New Jersey","NJ",34,22,12,"US President","Boss, Jeffery","vote here",FALSE,639,3868237,20171015,NA
+2008,"New Jersey","NJ",34,22,12,"US President","Calero, Roger","socialist workers",FALSE,523,3868237,20171015,NA
+2008,"New Jersey","NJ",34,22,12,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,416,3868237,20171015,NA
+2008,"New Mexico","NM",35,85,66,"US President","Obama, Barack H.","democrat",FALSE,472422,830158,20171015,NA
+2008,"New Mexico","NM",35,85,66,"US President","McCain, John","republican",FALSE,346832,830158,20171015,NA
+2008,"New Mexico","NM",35,85,66,"US President","Nader, Ralph","independent",FALSE,5327,830158,20171015,NA
+2008,"New Mexico","NM",35,85,66,"US President","Barr, Bob","libertarian",FALSE,2428,830158,20171015,NA
+2008,"New Mexico","NM",35,85,66,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,1597,830158,20171015,NA
+2008,"New Mexico","NM",35,85,66,"US President","McKinney, Cynthia","green",FALSE,1552,830158,20171015,NA
+2008,"New York","NY",36,21,13,"US President","Obama, Barack H.","democrat",FALSE,4645332,7722019,20171015,NA
+2008,"New York","NY",36,21,13,"US President","McCain, John","republican",FALSE,2418323,7722019,20171015,NA
+2008,"New York","NY",36,21,13,"US President","McCain, John","conservative",FALSE,170475,7722019,20171015,NA
+2008,"New York","NY",36,21,13,"US President","McCain, John","independence",FALSE,163973,7722019,20171015,NA
+2008,"New York","NY",36,21,13,"US President","Obama, Barack H.","working families",FALSE,159613,7722019,20171015,NA
+2008,"New York","NY",36,21,13,"US President","Blank Vote/Scattering","",FALSE,84701,7722019,20171015,NA
+2008,"New York","NY",36,21,13,"US President","Nader, Ralph","populist",FALSE,41249,7722019,20171015,NA
+2008,"New York","NY",36,21,13,"US President","Barr, Bob","libertarian",FALSE,19596,7722019,20171015,NA
+2008,"New York","NY",36,21,13,"US President","McKinney, Cynthia","green",FALSE,12801,7722019,20171015,NA
+2008,"New York","NY",36,21,13,"US President","Harris, James","socialist workers",FALSE,3615,7722019,20171015,NA
+2008,"New York","NY",36,21,13,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,1639,7722019,20171015,NA
+2008,"New York","NY",36,21,13,"US President","","",TRUE,702,7722019,20171015,NA
+2008,"North Carolina","NC",37,56,47,"US President","Obama, Barack H.","democrat",FALSE,2142651,4310851,20171015,NA
+2008,"North Carolina","NC",37,56,47,"US President","McCain, John","republican",FALSE,2128474,4310851,20171015,NA
+2008,"North Carolina","NC",37,56,47,"US President","Barr, Bob","libertarian",FALSE,25722,4310851,20171015,NA
+2008,"North Carolina","NC",37,56,47,"US President","","",TRUE,12494,4310851,20171015,NA
+2008,"North Carolina","NC",37,56,47,"US President","Nader, Ralph","independent",TRUE,1510,4310851,20171015,NA
+2008,"North Dakota","ND",38,44,36,"US President","McCain, John","republican",FALSE,168601,316621,20171015,NA
+2008,"North Dakota","ND",38,44,36,"US President","Obama, Barack H.","democrat",FALSE,141278,316621,20171015,NA
+2008,"North Dakota","ND",38,44,36,"US President","Nader, Ralph","independent",FALSE,4189,316621,20171015,NA
+2008,"North Dakota","ND",38,44,36,"US President","Barr, Bob","libertarian",FALSE,1354,316621,20171015,NA
+2008,"North Dakota","ND",38,44,36,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,1199,316621,20171015,NA
+2008,"Ohio","OH",39,31,24,"US President","Obama, Barack H.","democrat",FALSE,2940044,5708350,20171015,NA
+2008,"Ohio","OH",39,31,24,"US President","McCain, John","republican",FALSE,2677820,5708350,20171015,NA
+2008,"Ohio","OH",39,31,24,"US President","Nader, Ralph","independent",FALSE,46242,5708350,20171015,NA
+2008,"Ohio","OH",39,31,24,"US President","Barr, Bob","libertarian",FALSE,19917,5708350,20171015,NA
+2008,"Ohio","OH",39,31,24,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,12565,5708350,20171015,NA
+2008,"Ohio","OH",39,31,24,"US President","McKinney, Cynthia","green",FALSE,8518,5708350,20171015,NA
+2008,"Ohio","OH",39,31,24,"US President","Moore, Brian","socialist",FALSE,2735,5708350,20171015,NA
+2008,"Ohio","OH",39,31,24,"US President","","independent",TRUE,509,5708350,20171015,NA
+2008,"Oklahoma","OK",40,73,53,"US President","McCain, John","republican",FALSE,960165,1462661,20171015,NA
+2008,"Oklahoma","OK",40,73,53,"US President","Obama, Barack H.","democrat",FALSE,502496,1462661,20171015,NA
+2008,"Oregon","OR",41,92,72,"US President","Obama, Barack H.","democrat",FALSE,1037291,1827864,20171015,NA
+2008,"Oregon","OR",41,92,72,"US President","McCain, John","republican",FALSE,738475,1827864,20171015,NA
+2008,"Oregon","OR",41,92,72,"US President","Nader, Ralph","peace party",FALSE,18614,1827864,20171015,NA
+2008,"Oregon","OR",41,92,72,"US President","Other","",FALSE,13613,1827864,20171015,NA
+2008,"Oregon","OR",41,92,72,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,7693,1827864,20171015,NA
+2008,"Oregon","OR",41,92,72,"US President","","libertarian",FALSE,7635,1827864,20171015,NA
+2008,"Oregon","OR",41,92,72,"US President","McKinney, Cynthia","green",FALSE,4543,1827864,20171015,NA
+2008,"Pennsylvania","PA",42,23,14,"US President","Obama, Barack H.","democrat",FALSE,3276363,6013272,20171015,NA
+2008,"Pennsylvania","PA",42,23,14,"US President","McCain, John","republican",FALSE,2655885,6013272,20171015,NA
+2008,"Pennsylvania","PA",42,23,14,"US President","Nader, Ralph","independent",FALSE,42977,6013272,20171015,NA
+2008,"Pennsylvania","PA",42,23,14,"US President","Barr, Bob","libertarian",FALSE,19912,6013272,20171015,NA
+2008,"Pennsylvania","PA",42,23,14,"US President","","",TRUE,9955,6013272,20171015,NA
+2008,"Pennsylvania","PA",42,23,14,"US President","Scattering","",FALSE,8180,6013272,20171015,NA
+2008,"Rhode Island","RI",44,15,5,"US President","Obama, Barack H.","democrat",FALSE,296571,471766,20171015,NA
+2008,"Rhode Island","RI",44,15,5,"US President","McCain, John","republican",FALSE,165391,471766,20171015,NA
+2008,"Rhode Island","RI",44,15,5,"US President","Nader, Ralph","independent",FALSE,4829,471766,20171015,NA
+2008,"Rhode Island","RI",44,15,5,"US President","","",TRUE,1999,471766,20171015,NA
+2008,"Rhode Island","RI",44,15,5,"US President","Barr, Bob","libertarian",FALSE,1382,471766,20171015,NA
+2008,"Rhode Island","RI",44,15,5,"US President","McKinney, Cynthia","green",FALSE,797,471766,20171015,NA
+2008,"Rhode Island","RI",44,15,5,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,675,471766,20171015,NA
+2008,"Rhode Island","RI",44,15,5,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,122,471766,20171015,NA
+2008,"South Carolina","SC",45,57,48,"US President","McCain, John","republican",FALSE,1034896,1920969,20171015,NA
+2008,"South Carolina","SC",45,57,48,"US President","Obama, Barack H.","democrat",FALSE,862449,1920969,20171015,NA
+2008,"South Carolina","SC",45,57,48,"US President","Barr, Bob","libertarian",FALSE,7283,1920969,20171015,NA
+2008,"South Carolina","SC",45,57,48,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,6827,1920969,20171015,NA
+2008,"South Carolina","SC",45,57,48,"US President","Nader, Ralph","independent",FALSE,5053,1920969,20171015,NA
+2008,"South Carolina","SC",45,57,48,"US President","McKinney, Cynthia","green",FALSE,4461,1920969,20171015,NA
+2008,"South Dakota","SD",46,45,37,"US President","McCain, John","republican",FALSE,203054,381975,20171015,NA
+2008,"South Dakota","SD",46,45,37,"US President","Obama, Barack H.","democrat",FALSE,170924,381975,20171015,NA
+2008,"South Dakota","SD",46,45,37,"US President","Nader, Ralph","independent",FALSE,4267,381975,20171015,NA
+2008,"South Dakota","SD",46,45,37,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,1895,381975,20171015,NA
+2008,"South Dakota","SD",46,45,37,"US President","Barr, Bob","libertarian",FALSE,1835,381975,20171015,NA
+2008,"Tennessee","TN",47,62,54,"US President","McCain, John","republican",FALSE,1479178,2599749,20171015,NA
+2008,"Tennessee","TN",47,62,54,"US President","Obama, Barack H.","democrat",FALSE,1087437,2599749,20171015,NA
+2008,"Tennessee","TN",47,62,54,"US President","","independent",FALSE,33134,2599749,20171015,NA
+2008,"Texas","TX",48,74,49,"US President","McCain, John","republican",FALSE,4479328,8077795,20171015,NA
+2008,"Texas","TX",48,74,49,"US President","Obama, Barack H.","democrat",FALSE,3528633,8077795,20171015,NA
+2008,"Texas","TX",48,74,49,"US President","Barr, Bob","libertarian",FALSE,56116,8077795,20171015,NA
+2008,"Texas","TX",48,74,49,"US President","","",TRUE,7967,8077795,20171015,NA
+2008,"Texas","TX",48,74,49,"US President","Nader, Ralph","independent",TRUE,5751,8077795,20171015,NA
+2008,"Utah","UT",49,87,67,"US President","McCain, John","republican",FALSE,596030,952370,20171015,NA
+2008,"Utah","UT",49,87,67,"US President","Obama, Barack H.","democrat",FALSE,327670,952370,20171015,NA
+2008,"Utah","UT",49,87,67,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,12012,952370,20171015,NA
+2008,"Utah","UT",49,87,67,"US President","Nader, Ralph","peace & freedom",FALSE,8416,952370,20171015,NA
+2008,"Utah","UT",49,87,67,"US President","Barr, Bob","libertarian",FALSE,6966,952370,20171015,NA
+2008,"Utah","UT",49,87,67,"US President","McKinney, Cynthia","green",FALSE,982,952370,20171015,NA
+2008,"Utah","UT",49,87,67,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,262,952370,20171015,NA
+2008,"Utah","UT",49,87,67,"US President","","",TRUE,32,952370,20171015,NA
+2008,"Vermont","VT",50,13,6,"US President","Obama, Barack H.","democrat",FALSE,219262,325046,20171015,NA
+2008,"Vermont","VT",50,13,6,"US President","McCain, John","republican",FALSE,98974,325046,20171015,NA
+2008,"Vermont","VT",50,13,6,"US President","Nader, Ralph","independent",FALSE,3339,325046,20171015,NA
+2008,"Vermont","VT",50,13,6,"US President","","",TRUE,1464,325046,20171015,NA
+2008,"Vermont","VT",50,13,6,"US President","Barr, Bob","libertarian",FALSE,1067,325046,20171015,NA
+2008,"Vermont","VT",50,13,6,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,500,325046,20171015,NA
+2008,"Vermont","VT",50,13,6,"US President","Calero, Roger","socialist workers",FALSE,150,325046,20171015,NA
+2008,"Vermont","VT",50,13,6,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,149,325046,20171015,NA
+2008,"Vermont","VT",50,13,6,"US President","Moore, Brian","liberty union party",FALSE,141,325046,20171015,NA
+2008,"Virginia","VA",51,54,40,"US President","Obama, Barack H.","democrat",FALSE,1959532,3723260,20171015,NA
+2008,"Virginia","VA",51,54,40,"US President","McCain, John","republican",FALSE,1725005,3723260,20171015,NA
+2008,"Virginia","VA",51,54,40,"US President","Nader, Ralph","independent",FALSE,11483,3723260,20171015,NA
+2008,"Virginia","VA",51,54,40,"US President","Barr, Bob","libertarian",FALSE,11067,3723260,20171015,NA
+2008,"Virginia","VA",51,54,40,"US President","Baldwin, Charles """"Chuck""""","independent green",FALSE,7474,3723260,20171015,NA
+2008,"Virginia","VA",51,54,40,"US President","","",TRUE,6355,3723260,20171015,NA
+2008,"Virginia","VA",51,54,40,"US President","McKinney, Cynthia","green",FALSE,2344,3723260,20171015,NA
+2008,"Washington","WA",53,91,73,"US President","Obama, Barack H.","democrat",FALSE,1750848,3036878,20171015,NA
+2008,"Washington","WA",53,91,73,"US President","McCain, John","republican",FALSE,1229216,3036878,20171015,NA
+2008,"Washington","WA",53,91,73,"US President","Nader, Ralph","independent",FALSE,29489,3036878,20171015,NA
+2008,"Washington","WA",53,91,73,"US President","Barr, Bob","libertarian",FALSE,12728,3036878,20171015,NA
+2008,"Washington","WA",53,91,73,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,9432,3036878,20171015,NA
+2008,"Washington","WA",53,91,73,"US President","McKinney, Cynthia","green",FALSE,3819,3036878,20171015,NA
+2008,"Washington","WA",53,91,73,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,705,3036878,20171015,NA
+2008,"Washington","WA",53,91,73,"US President","Harris, James","socialist workers",FALSE,641,3036878,20171015,NA
+2008,"West Virginia","WV",54,55,56,"US President","McCain, John","republican",FALSE,397466,713451,20171015,NA
+2008,"West Virginia","WV",54,55,56,"US President","Obama, Barack H.","democrat",FALSE,303857,713451,20171015,NA
+2008,"West Virginia","WV",54,55,56,"US President","Nader, Ralph","independent",FALSE,7219,713451,20171015,NA
+2008,"West Virginia","WV",54,55,56,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,2465,713451,20171015,NA
+2008,"West Virginia","WV",54,55,56,"US President","McKinney, Cynthia","mountain party",FALSE,2355,713451,20171015,NA
+2008,"West Virginia","WV",54,55,56,"US President","","",TRUE,89,713451,20171015,NA
+2008,"Wisconsin","WI",55,35,25,"US President","Obama, Barack H.","democrat",FALSE,1677211,2983417,20171015,NA
+2008,"Wisconsin","WI",55,35,25,"US President","McCain, John","republican",FALSE,1262393,2983417,20171015,NA
+2008,"Wisconsin","WI",55,35,25,"US President","Nader, Ralph","independent",FALSE,17605,2983417,20171015,NA
+2008,"Wisconsin","WI",55,35,25,"US President","Barr, Bob","libertarian",FALSE,8858,2983417,20171015,NA
+2008,"Wisconsin","WI",55,35,25,"US President","Scattering","",FALSE,6521,2983417,20171015,NA
+2008,"Wisconsin","WI",55,35,25,"US President","Baldwin, Charles """"Chuck""""","constitution party",FALSE,5072,2983417,20171015,NA
+2008,"Wisconsin","WI",55,35,25,"US President","McKinney, Cynthia","green",FALSE,4216,2983417,20171015,NA
+2008,"Wisconsin","WI",55,35,25,"US President","Wamboldt, Jeffrey","we the people",FALSE,764,2983417,20171015,NA
+2008,"Wisconsin","WI",55,35,25,"US President","Moore, Brian","socialist party usa",FALSE,540,2983417,20171015,NA
+2008,"Wisconsin","WI",55,35,25,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,237,2983417,20171015,NA
+2008,"Wyoming","WY",56,83,68,"US President","McCain, John","republican",FALSE,164958,254904,20171015,NA
+2008,"Wyoming","WY",56,83,68,"US President","Obama, Barack H.","democrat",FALSE,82868,254904,20171015,NA
+2008,"Wyoming","WY",56,83,68,"US President","","independent",FALSE,3717,254904,20171015,NA
+2008,"Wyoming","WY",56,83,68,"US President","Barr, Bob","libertarian",FALSE,1594,254904,20171015,NA
+2008,"Wyoming","WY",56,83,68,"US President","","",TRUE,1521,254904,20171015,NA
+2008,"Wyoming","WY",56,83,68,"US President","Over Vote","",FALSE,246,254904,20171015,NA
+2012,"Alabama","AL",1,63,41,"US President","Romney, Mitt","republican",FALSE,1255925,2074338,20171015,NA
+2012,"Alabama","AL",1,63,41,"US President","Obama, Barack H.","democrat",FALSE,795696,2074338,20171015,NA
+2012,"Alabama","AL",1,63,41,"US President","","independent",FALSE,18706,2074338,20171015,NA
+2012,"Alabama","AL",1,63,41,"US President","","",TRUE,4011,2074338,20171015,NA
+2012,"Alaska","AK",2,94,81,"US President","Romney, Mitt","republican",FALSE,164676,300495,20171015,NA
+2012,"Alaska","AK",2,94,81,"US President","Obama, Barack H.","democrat",FALSE,122640,300495,20171015,NA
+2012,"Alaska","AK",2,94,81,"US President","Johnson, Gary","libertarian",FALSE,7392,300495,20171015,NA
+2012,"Alaska","AK",2,94,81,"US President","Stein, Jill","green",FALSE,2917,300495,20171015,NA
+2012,"Alaska","AK",2,94,81,"US President","","",TRUE,2870,300495,20171015,NA
+2012,"Arizona","AZ",4,86,61,"US President","Romney, Mitt","republican",FALSE,1233654,2299254,20171015,NA
+2012,"Arizona","AZ",4,86,61,"US President","Obama, Barack H.","democrat",FALSE,1025232,2299254,20171015,NA
+2012,"Arizona","AZ",4,86,61,"US President","Johnson, Gary","libertarian",FALSE,32100,2299254,20171015,NA
+2012,"Arizona","AZ",4,86,61,"US President","Stein, Jill","green",FALSE,7816,2299254,20171015,NA
+2012,"Arizona","AZ",4,86,61,"US President","","",TRUE,452,2299254,20171015,NA
+2012,"Arkansas","AR",5,71,42,"US President","Romney, Mitt","republican",FALSE,647744,1069468,20171015,NA
+2012,"Arkansas","AR",5,71,42,"US President","Obama, Barack H.","democrat",FALSE,394409,1069468,20171015,NA
+2012,"Arkansas","AR",5,71,42,"US President","Johnson, Gary","libertarian",FALSE,16276,1069468,20171015,NA
+2012,"Arkansas","AR",5,71,42,"US President","Stein, Jill","green",FALSE,9305,1069468,20171015,NA
+2012,"Arkansas","AR",5,71,42,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,1734,1069468,20171015,NA
+2012,"California","CA",6,93,71,"US President","Obama, Barack H.","democrat",FALSE,7854285,13038547,20171015,NA
+2012,"California","CA",6,93,71,"US President","Romney, Mitt","republican",FALSE,4839958,13038547,20171015,NA
+2012,"California","CA",6,93,71,"US President","Johnson, Gary","libertarian",FALSE,143221,13038547,20171015,NA
+2012,"California","CA",6,93,71,"US President","Stein, Jill","green",FALSE,85638,13038547,20171015,NA
+2012,"California","CA",6,93,71,"US President","Barr, Roseanne","peace & freedom",FALSE,53824,13038547,20171015,NA
+2012,"California","CA",6,93,71,"US President","Hoefling, Thomas Conrad """"Tom""""","american independent party",FALSE,38372,13038547,20171015,NA
+2012,"California","CA",6,93,71,"US President","","",TRUE,23249,13038547,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","Obama, Barack H.","democrat",FALSE,1323101,2569516,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","Romney, Mitt","republican",FALSE,1185243,2569516,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","Johnson, Gary","libertarian",FALSE,35545,2569516,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","Stein, Jill","green",FALSE,7508,2569516,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","Goode, Virgil Hamlin, Jr.","american constitution party",FALSE,6234,2569516,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","Barr, Roseanne","peace & freedom",FALSE,5057,2569516,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","Reed, Jill Ann","no party affiliation",FALSE,2588,2569516,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","Anderson, Ross Carl """"Rocky""""","justice",FALSE,1262,2569516,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","Tittle, Sheila """"Samm""""","we the people",FALSE,791,2569516,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","Hoefling, Thomas Conrad """"Tom""""","america's party",FALSE,679,2569516,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,317,2569516,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","Alexander, Stewart","socialist",FALSE,308,2569516,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","Miller, Merlin","american third position",FALSE,267,2569516,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","Stevens, Thomas Robert """"Tom""""","objectivist party",FALSE,235,2569516,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","Harris, James","socialist workers",FALSE,192,2569516,20171015,NA
+2012,"Colorado","CO",8,84,62,"US President","White, Jerry","socialist equality party",FALSE,189,2569516,20171015,NA
+2012,"Connecticut","CT",9,16,1,"US President","Obama, Barack H.","democrat",FALSE,905083,1558204,20171015,NA
+2012,"Connecticut","CT",9,16,1,"US President","Romney, Mitt","republican",FALSE,634892,1558204,20171015,NA
+2012,"Connecticut","CT",9,16,1,"US President","Johnson, Gary","libertarian",FALSE,12340,1558204,20171015,NA
+2012,"Connecticut","CT",9,16,1,"US President","","independent",FALSE,4971,1558204,20171015,NA
+2012,"Connecticut","CT",9,16,1,"US President","","",TRUE,918,1558204,20171015,NA
+2012,"Delaware","DE",10,51,11,"US President","Obama, Barack H.","democrat",FALSE,242584,413890,20171015,NA
+2012,"Delaware","DE",10,51,11,"US President","Romney, Mitt","republican",FALSE,165484,413890,20171015,NA
+2012,"Delaware","DE",10,51,11,"US President","Johnson, Gary","libertarian",FALSE,3882,413890,20171015,NA
+2012,"Delaware","DE",10,51,11,"US President","Stein, Jill","green",FALSE,1940,413890,20171015,NA
+2012,"District of Columbia","DC",11,53,55,"US President","Obama, Barack H.","democrat",FALSE,267070,293764,20171015,NA
+2012,"District of Columbia","DC",11,53,55,"US President","Romney, Mitt","republican",FALSE,21381,293764,20171015,NA
+2012,"District of Columbia","DC",11,53,55,"US President","Stein, Jill","d.c. statehood green",FALSE,2458,293764,20171015,NA
+2012,"District of Columbia","DC",11,53,55,"US President","Johnson, Gary","libertarian",FALSE,2083,293764,20171015,NA
+2012,"District of Columbia","DC",11,53,55,"US President","","",TRUE,772,293764,20171015,NA
+2012,"Florida","FL",12,59,43,"US President","Obama, Barack H.","democrat",FALSE,4237756,8474179,20171015,NA
+2012,"Florida","FL",12,59,43,"US President","Romney, Mitt","republican",FALSE,4163447,8474179,20171015,NA
+2012,"Florida","FL",12,59,43,"US President","Johnson, Gary","libertarian",FALSE,44726,8474179,20171015,NA
+2012,"Florida","FL",12,59,43,"US President","Stein, Jill","green",FALSE,8947,8474179,20171015,NA
+2012,"Florida","FL",12,59,43,"US President","Barr, Roseanne","peace & freedom",FALSE,8154,8474179,20171015,NA
+2012,"Florida","FL",12,59,43,"US President","Stevens, Thomas Robert """"Tom""""","objectivist party",FALSE,3856,8474179,20171015,NA
+2012,"Florida","FL",12,59,43,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,2607,8474179,20171015,NA
+2012,"Florida","FL",12,59,43,"US President","Anderson, Ross Carl """"Rocky""""","justice",FALSE,1754,8474179,20171015,NA
+2012,"Florida","FL",12,59,43,"US President","Hoefling, Thomas Conrad """"Tom""""","american independent",FALSE,946,8474179,20171015,NA
+2012,"Florida","FL",12,59,43,"US President","Barnett, Andre","reform party",FALSE,820,8474179,20171015,NA
+2012,"Florida","FL",12,59,43,"US President","Alexander, Stewart","socialist",FALSE,799,8474179,20171015,NA
+2012,"Florida","FL",12,59,43,"US President","Lindsay, Peta","socialism and liberation party",FALSE,322,8474179,20171015,NA
+2012,"Florida","FL",12,59,43,"US President","","",TRUE,45,8474179,20171015,NA
+2012,"Georgia","GA",13,58,44,"US President","Romney, Mitt","republican",FALSE,2078688,3897839,20171015,NA
+2012,"Georgia","GA",13,58,44,"US President","Obama, Barack H.","democrat",FALSE,1773827,3897839,20171015,NA
+2012,"Georgia","GA",13,58,44,"US President","Johnson, Gary","libertarian",FALSE,45324,3897839,20171015,NA
+2012,"Hawaii","HI",15,95,82,"US President","Obama, Barack H.","democrat",FALSE,306658,437159,20171015,NA
+2012,"Hawaii","HI",15,95,82,"US President","Romney, Mitt","republican",FALSE,121015,437159,20171015,NA
+2012,"Hawaii","HI",15,95,82,"US President","Johnson, Gary","libertarian",FALSE,3840,437159,20171015,NA
+2012,"Hawaii","HI",15,95,82,"US President","Stein, Jill","green",FALSE,3184,437159,20171015,NA
+2012,"Hawaii","HI",15,95,82,"US President","Blank Vote","",FALSE,2227,437159,20171015,NA
+2012,"Hawaii","HI",15,95,82,"US President","Over Vote","",FALSE,235,437159,20171015,NA
+2012,"Idaho","ID",16,82,63,"US President","Romney, Mitt","republican",FALSE,420911,652274,20171015,NA
+2012,"Idaho","ID",16,82,63,"US President","Obama, Barack H.","democrat",FALSE,212787,652274,20171015,NA
+2012,"Idaho","ID",16,82,63,"US President","Johnson, Gary","libertarian",FALSE,9453,652274,20171015,NA
+2012,"Idaho","ID",16,82,63,"US President","","independent",FALSE,6901,652274,20171015,NA
+2012,"Idaho","ID",16,82,63,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,2222,652274,20171015,NA
+2012,"Illinois","IL",17,33,21,"US President","Obama, Barack H.","democrat",FALSE,3019512,5242014,20171015,NA
+2012,"Illinois","IL",17,33,21,"US President","Romney, Mitt","republican",FALSE,2135216,5242014,20171015,NA
+2012,"Illinois","IL",17,33,21,"US President","Johnson, Gary","libertarian",FALSE,56229,5242014,20171015,NA
+2012,"Illinois","IL",17,33,21,"US President","Stein, Jill","green",FALSE,30222,5242014,20171015,NA
+2012,"Illinois","IL",17,33,21,"US President","","",TRUE,835,5242014,20171015,NA
+2012,"Indiana","IN",18,32,22,"US President","Romney, Mitt","republican",FALSE,1420543,2624534,20171015,NA
+2012,"Indiana","IN",18,32,22,"US President","Obama, Barack H.","democrat",FALSE,1152887,2624534,20171015,NA
+2012,"Indiana","IN",18,32,22,"US President","Johnson, Gary","libertarian",FALSE,50111,2624534,20171015,NA
+2012,"Indiana","IN",18,32,22,"US President","","",TRUE,993,2624534,20171015,NA
+2012,"Iowa","IA",19,42,31,"US President","Obama, Barack H.","democrat",FALSE,822544,1582180,20171015,NA
+2012,"Iowa","IA",19,42,31,"US President","Romney, Mitt","republican",FALSE,730617,1582180,20171015,NA
+2012,"Iowa","IA",19,42,31,"US President","Johnson, Gary","libertarian",FALSE,12926,1582180,20171015,NA
+2012,"Iowa","IA",19,42,31,"US President","","",TRUE,7442,1582180,20171015,NA
+2012,"Iowa","IA",19,42,31,"US President","Stein, Jill","green",FALSE,3769,1582180,20171015,NA
+2012,"Iowa","IA",19,42,31,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,3038,1582180,20171015,NA
+2012,"Iowa","IA",19,42,31,"US President","","nominated by petition",FALSE,1027,1582180,20171015,NA
+2012,"Iowa","IA",19,42,31,"US President","Harris, James","socialist workers",FALSE,445,1582180,20171015,NA
+2012,"Iowa","IA",19,42,31,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,372,1582180,20171015,NA
+2012,"Kansas","KS",20,47,32,"US President","Romney, Mitt","republican",FALSE,692634,1159971,20171015,NA
+2012,"Kansas","KS",20,47,32,"US President","Obama, Barack H.","democrat",FALSE,440726,1159971,20171015,NA
+2012,"Kansas","KS",20,47,32,"US President","Johnson, Gary","libertarian",FALSE,20456,1159971,20171015,NA
+2012,"Kansas","KS",20,47,32,"US President","Baldwin, Charles """"Chuck""""","reform party",FALSE,5017,1159971,20171015,NA
+2012,"Kansas","KS",20,47,32,"US President","","",TRUE,1138,1159971,20171015,NA
+2012,"Kentucky","KY",21,61,51,"US President","Romney, Mitt","republican",FALSE,1087190,1797212,20171015,NA
+2012,"Kentucky","KY",21,61,51,"US President","Obama, Barack H.","democrat",FALSE,679370,1797212,20171015,NA
+2012,"Kentucky","KY",21,61,51,"US President","Johnson, Gary","libertarian",FALSE,17063,1797212,20171015,NA
+2012,"Kentucky","KY",21,61,51,"US President","Terry, Randall","independent",FALSE,6872,1797212,20171015,NA
+2012,"Kentucky","KY",21,61,51,"US President","Stein, Jill","green",FALSE,6337,1797212,20171015,NA
+2012,"Kentucky","KY",21,61,51,"US President","","",TRUE,380,1797212,20171015,NA
+2012,"Louisiana","LA",22,72,45,"US President","Romney, Mitt","republican",FALSE,1152262,1994065,20171015,NA
+2012,"Louisiana","LA",22,72,45,"US President","Obama, Barack H.","democrat",FALSE,809141,1994065,20171015,NA
+2012,"Louisiana","LA",22,72,45,"US President","Johnson, Gary","libertarian",FALSE,18157,1994065,20171015,NA
+2012,"Louisiana","LA",22,72,45,"US President","Stein, Jill","green",FALSE,6978,1994065,20171015,NA
+2012,"Louisiana","LA",22,72,45,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,2508,1994065,20171015,NA
+2012,"Louisiana","LA",22,72,45,"US President","Tittle, Sheila """"Samm""""","we the people",FALSE,1767,1994065,20171015,NA
+2012,"Louisiana","LA",22,72,45,"US President","Anderson, Ross Carl """"Rocky""""","justice",FALSE,1368,1994065,20171015,NA
+2012,"Louisiana","LA",22,72,45,"US President","Lindsay, Peta","socialism and liberation party",FALSE,622,1994065,20171015,NA
+2012,"Louisiana","LA",22,72,45,"US President","Fellure, Lowell Jackson """"Jack""""","prohibition",FALSE,518,1994065,20171015,NA
+2012,"Louisiana","LA",22,72,45,"US President","Harris, James","socialist workers",FALSE,389,1994065,20171015,NA
+2012,"Louisiana","LA",22,72,45,"US President","White, Jerome """"Jerry""""","socialist equality party",FALSE,355,1994065,20171015,NA
+2012,"Maine","ME",23,11,2,"US President","Obama, Barack H.","democrat",FALSE,401306,724758,20171015,NA
+2012,"Maine","ME",23,11,2,"US President","Romney, Mitt","republican",FALSE,292276,724758,20171015,NA
+2012,"Maine","ME",23,11,2,"US President","Blank Vote","",FALSE,11578,724758,20171015,NA
+2012,"Maine","ME",23,11,2,"US President","Johnson, Gary","libertarian",FALSE,9352,724758,20171015,NA
+2012,"Maine","ME",23,11,2,"US President","Stein, Jill","green",FALSE,8119,724758,20171015,NA
+2012,"Maine","ME",23,11,2,"US President","","",TRUE,2127,724758,20171015,NA
+2012,"Maryland","MD",24,52,52,"US President","Obama, Barack H.","democrat",FALSE,1677844,2707327,20171015,NA
+2012,"Maryland","MD",24,52,52,"US President","Romney, Mitt","republican",FALSE,971869,2707327,20171015,NA
+2012,"Maryland","MD",24,52,52,"US President","Johnson, Gary","libertarian",FALSE,30195,2707327,20171015,NA
+2012,"Maryland","MD",24,52,52,"US President","Stein, Jill","green",FALSE,17110,2707327,20171015,NA
+2012,"Maryland","MD",24,52,52,"US President","","",TRUE,10309,2707327,20171015,NA
+2012,"Massachusetts","MA",25,14,3,"US President","Obama, Barack H.","democrat",FALSE,1921290,3184196,20171015,NA
+2012,"Massachusetts","MA",25,14,3,"US President","Romney, Mitt","republican",FALSE,1188314,3184196,20171015,NA
+2012,"Massachusetts","MA",25,14,3,"US President","Johnson, Gary","libertarian",FALSE,30920,3184196,20171015,NA
+2012,"Massachusetts","MA",25,14,3,"US President","Stein, Jill","green-rainbow",FALSE,20691,3184196,20171015,NA
+2012,"Massachusetts","MA",25,14,3,"US President","Blank Vote/Scattering","",FALSE,16429,3184196,20171015,NA
+2012,"Massachusetts","MA",25,14,3,"US President","Other","",FALSE,6552,3184196,20171015,NA
+2012,"Michigan","MI",26,34,23,"US President","Obama, Barack H.","democrat",FALSE,2564569,4730961,20171015,NA
+2012,"Michigan","MI",26,34,23,"US President","Romney, Mitt","republican",FALSE,2115256,4730961,20171015,NA
+2012,"Michigan","MI",26,34,23,"US President","Stein, Jill","green",FALSE,21897,4730961,20171015,NA
+2012,"Michigan","MI",26,34,23,"US President","Goode, Virgil Hamlin, Jr.","u.s. taxpayers party",FALSE,16119,4730961,20171015,NA
+2012,"Michigan","MI",26,34,23,"US President","","",TRUE,7973,4730961,20171015,NA
+2012,"Michigan","MI",26,34,23,"US President","Anderson, Ross Carl """"Rocky""""","natural law",FALSE,5147,4730961,20171015,NA
+2012,"Minnesota","MN",27,41,33,"US President","Obama, Barack H.","democratic-farmer-labor",FALSE,1546167,2936561,20171015,NA
+2012,"Minnesota","MN",27,41,33,"US President","Romney, Mitt","republican",FALSE,1320225,2936561,20171015,NA
+2012,"Minnesota","MN",27,41,33,"US President","Johnson, Gary","libertarian",FALSE,35098,2936561,20171015,NA
+2012,"Minnesota","MN",27,41,33,"US President","Stein, Jill","green",FALSE,13023,2936561,20171015,NA
+2012,"Minnesota","MN",27,41,33,"US President","","",TRUE,10641,2936561,20171015,NA
+2012,"Minnesota","MN",27,41,33,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,3722,2936561,20171015,NA
+2012,"Minnesota","MN",27,41,33,"US President","Carlson, Jim","grassroots",FALSE,3149,2936561,20171015,NA
+2012,"Minnesota","MN",27,41,33,"US President","Anderson, Ross Carl """"Rocky""""","justice",FALSE,1996,2936561,20171015,NA
+2012,"Minnesota","MN",27,41,33,"US President","Morstad, Dean","constitutional government",FALSE,1092,2936561,20171015,NA
+2012,"Minnesota","MN",27,41,33,"US President","Harris, James","socialist workers",FALSE,1051,2936561,20171015,NA
+2012,"Minnesota","MN",27,41,33,"US President","Lindsay, Peta","socialism and liberation party",FALSE,397,2936561,20171015,NA
+2012,"Mississippi","MS",28,64,46,"US President","Romney, Mitt","republican",FALSE,710746,1285584,20171015,NA
+2012,"Mississippi","MS",28,64,46,"US President","Obama, Barack H.","democrat",FALSE,562949,1285584,20171015,NA
+2012,"Mississippi","MS",28,64,46,"US President","Johnson, Gary","libertarian",FALSE,6676,1285584,20171015,NA
+2012,"Mississippi","MS",28,64,46,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,2609,1285584,20171015,NA
+2012,"Mississippi","MS",28,64,46,"US President","Stein, Jill","green",FALSE,1588,1285584,20171015,NA
+2012,"Mississippi","MS",28,64,46,"US President","Washer, Barbara Dale","reform party",FALSE,1016,1285584,20171015,NA
+2012,"Missouri","MO",29,43,34,"US President","Romney, Mitt","republican",FALSE,1482440,2757323,20171015,NA
+2012,"Missouri","MO",29,43,34,"US President","Obama, Barack H.","democrat",FALSE,1223796,2757323,20171015,NA
+2012,"Missouri","MO",29,43,34,"US President","Johnson, Gary","libertarian",FALSE,43151,2757323,20171015,NA
+2012,"Missouri","MO",29,43,34,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,7936,2757323,20171015,NA
+2012,"Montana","MT",30,81,64,"US President","Romney, Mitt","republican",FALSE,267928,484048,20171015,NA
+2012,"Montana","MT",30,81,64,"US President","Obama, Barack H.","democrat",FALSE,201839,484048,20171015,NA
+2012,"Montana","MT",30,81,64,"US President","Johnson, Gary","libertarian",FALSE,14165,484048,20171015,NA
+2012,"Montana","MT",30,81,64,"US President","","",TRUE,116,484048,20171015,NA
+2012,"Nebraska","NE",31,46,35,"US President","Romney, Mitt","republican",FALSE,475064,794379,20171015,NA
+2012,"Nebraska","NE",31,46,35,"US President","Obama, Barack H.","democrat",FALSE,302081,794379,20171015,NA
+2012,"Nebraska","NE",31,46,35,"US President","Johnson, Gary","libertarian",FALSE,11109,794379,20171015,NA
+2012,"Nebraska","NE",31,46,35,"US President","","",TRUE,3717,794379,20171015,NA
+2012,"Nebraska","NE",31,46,35,"US President","","nominated by petition",FALSE,2408,794379,20171015,NA
+2012,"Nevada","NV",32,88,65,"US President","Obama, Barack H.","democrat",FALSE,531373,1014918,20171015,NA
+2012,"Nevada","NV",32,88,65,"US President","Romney, Mitt","republican",FALSE,463567,1014918,20171015,NA
+2012,"Nevada","NV",32,88,65,"US President","Johnson, Gary","libertarian",FALSE,10968,1014918,20171015,NA
+2012,"Nevada","NV",32,88,65,"US President","None Of These Candidates","",FALSE,5770,1014918,20171015,NA
+2012,"Nevada","NV",32,88,65,"US President","Goode, Virgil Hamlin, Jr.","independent american",FALSE,3240,1014918,20171015,NA
+2012,"New Hampshire","NH",33,12,4,"US President","Obama, Barack H.","democrat",FALSE,369561,710972,20171015,NA
+2012,"New Hampshire","NH",33,12,4,"US President","Romney, Mitt","republican",FALSE,329918,710972,20171015,NA
+2012,"New Hampshire","NH",33,12,4,"US President","Johnson, Gary","libertarian",FALSE,8212,710972,20171015,NA
+2012,"New Hampshire","NH",33,12,4,"US President","","",TRUE,1698,710972,20171015,NA
+2012,"New Hampshire","NH",33,12,4,"US President","Scattering","",FALSE,875,710972,20171015,NA
+2012,"New Hampshire","NH",33,12,4,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,708,710972,20171015,NA
+2012,"New Jersey","NJ",34,22,12,"US President","Obama, Barack H.","democrat",FALSE,2122786,3638499,20171015,NA
+2012,"New Jersey","NJ",34,22,12,"US President","Romney, Mitt","republican",FALSE,1478088,3638499,20171015,NA
+2012,"New Jersey","NJ",34,22,12,"US President","Johnson, Gary","libertarian",FALSE,21035,3638499,20171015,NA
+2012,"New Jersey","NJ",34,22,12,"US President","Stein, Jill","green",FALSE,9886,3638499,20171015,NA
+2012,"New Jersey","NJ",34,22,12,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,2063,3638499,20171015,NA
+2012,"New Jersey","NJ",34,22,12,"US President","Anderson, Ross Carl """"Rocky""""","justice",FALSE,1723,3638499,20171015,NA
+2012,"New Jersey","NJ",34,22,12,"US President","Boss, Jeffery","nsa did 911",FALSE,1024,3638499,20171015,NA
+2012,"New Jersey","NJ",34,22,12,"US President","Harris, James","socialist workers",FALSE,709,3638499,20171015,NA
+2012,"New Jersey","NJ",34,22,12,"US President","Miller, Merlin","american third position",FALSE,664,3638499,20171015,NA
+2012,"New Jersey","NJ",34,22,12,"US President","Lindsay, Peta","socialism and liberation party",FALSE,521,3638499,20171015,NA
+2012,"New Mexico","NM",35,85,66,"US President","Obama, Barack H.","democrat",FALSE,415335,783758,20171015,NA
+2012,"New Mexico","NM",35,85,66,"US President","Romney, Mitt","republican",FALSE,335788,783758,20171015,NA
+2012,"New Mexico","NM",35,85,66,"US President","Johnson, Gary","libertarian",FALSE,27788,783758,20171015,NA
+2012,"New Mexico","NM",35,85,66,"US President","Stein, Jill","green",FALSE,2691,783758,20171015,NA
+2012,"New Mexico","NM",35,85,66,"US President","","new mexico independent party",FALSE,1174,783758,20171015,NA
+2012,"New Mexico","NM",35,85,66,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,982,783758,20171015,NA
+2012,"New York","NY",36,21,13,"US President","Obama, Barack H.","democrat",FALSE,4324228,7116784,20171015,NA
+2012,"New York","NY",36,21,13,"US President","Romney, Mitt","republican",FALSE,2223397,7116784,20171015,NA
+2012,"New York","NY",36,21,13,"US President","Romney, Mitt","conservative",FALSE,262035,7116784,20171015,NA
+2012,"New York","NY",36,21,13,"US President","Obama, Barack H.","working families",FALSE,147643,7116784,20171015,NA
+2012,"New York","NY",36,21,13,"US President","Blank Vote/Void Vote/Scattering","",FALSE,63881,7116784,20171015,NA
+2012,"New York","NY",36,21,13,"US President","Johnson, Gary","libertarian",FALSE,47092,7116784,20171015,NA
+2012,"New York","NY",36,21,13,"US President","Stein, Jill","green",FALSE,39856,7116784,20171015,NA
+2012,"New York","NY",36,21,13,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,6270,7116784,20171015,NA
+2012,"New York","NY",36,21,13,"US President","Lindsay, Peta","socialism and liberation party",FALSE,2039,7116784,20171015,NA
+2012,"New York","NY",36,21,13,"US President","","",TRUE,343,7116784,20171015,NA
+2012,"North Carolina","NC",37,56,47,"US President","Romney, Mitt","republican",FALSE,2270395,4505372,20171015,NA
+2012,"North Carolina","NC",37,56,47,"US President","Obama, Barack H.","democrat",FALSE,2178391,4505372,20171015,NA
+2012,"North Carolina","NC",37,56,47,"US President","Johnson, Gary","libertarian",FALSE,44515,4505372,20171015,NA
+2012,"North Carolina","NC",37,56,47,"US President","","",TRUE,12071,4505372,20171015,NA
+2012,"North Dakota","ND",38,44,36,"US President","Romney, Mitt","republican",FALSE,188320,322932,20171015,NA
+2012,"North Dakota","ND",38,44,36,"US President","Obama, Barack H.","democrat",FALSE,124966,322932,20171015,NA
+2012,"North Dakota","ND",38,44,36,"US President","Johnson, Gary","libertarian",FALSE,5238,322932,20171015,NA
+2012,"North Dakota","ND",38,44,36,"US President","","",TRUE,1860,322932,20171015,NA
+2012,"North Dakota","ND",38,44,36,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,1186,322932,20171015,NA
+2012,"North Dakota","ND",38,44,36,"US President","Stein, Jill","green",FALSE,1362,322932,20171015,NA
+2012,"Ohio","OH",39,31,24,"US President","Obama, Barack H.","democrat",FALSE,2827621,5580822,20171015,NA
+2012,"Ohio","OH",39,31,24,"US President","Romney, Mitt","republican",FALSE,2661407,5580822,20171015,NA
+2012,"Ohio","OH",39,31,24,"US President","Johnson, Gary","libertarian",FALSE,49493,5580822,20171015,NA
+2012,"Ohio","OH",39,31,24,"US President","Stein, Jill","green",FALSE,18574,5580822,20171015,NA
+2012,"Ohio","OH",39,31,24,"US President","Duncan, Richard","independent",FALSE,12502,5580822,20171015,NA
+2012,"Ohio","OH",39,31,24,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,8151,5580822,20171015,NA
+2012,"Ohio","OH",39,31,24,"US President","Alexander, Stewart","socialist",FALSE,2967,5580822,20171015,NA
+2012,"Ohio","OH",39,31,24,"US President","","",TRUE,107,5580822,20171015,NA
+2012,"Oklahoma","OK",40,73,53,"US President","Romney, Mitt","republican",FALSE,891325,1334872,20171015,NA
+2012,"Oklahoma","OK",40,73,53,"US President","Obama, Barack H.","democrat",FALSE,443547,1334872,20171015,NA
+2012,"Oregon","OR",41,92,72,"US President","Obama, Barack H.","democrat",FALSE,970488,1789270,20171015,NA
+2012,"Oregon","OR",41,92,72,"US President","Romney, Mitt","republican",FALSE,754175,1789270,20171015,NA
+2012,"Oregon","OR",41,92,72,"US President","Johnson, Gary","libertarian",FALSE,24089,1789270,20171015,NA
+2012,"Oregon","OR",41,92,72,"US President","Stein, Jill","pacific green",FALSE,19427,1789270,20171015,NA
+2012,"Oregon","OR",41,92,72,"US President","Other","",FALSE,13275,1789270,20171015,NA
+2012,"Oregon","OR",41,92,72,"US President","Christensen, Will","constitution party",FALSE,4432,1789270,20171015,NA
+2012,"Oregon","OR",41,92,72,"US President","Anderson, Ross Carl """"Rocky""""","progressive",FALSE,3384,1789270,20171015,NA
+2012,"Pennsylvania","PA",42,23,14,"US President","Obama, Barack H.","democrat",FALSE,2990274,5742040,20171015,NA
+2012,"Pennsylvania","PA",42,23,14,"US President","Romney, Mitt","republican",FALSE,2680434,5742040,20171015,NA
+2012,"Pennsylvania","PA",42,23,14,"US President","Johnson, Gary","libertarian",FALSE,49991,5742040,20171015,NA
+2012,"Pennsylvania","PA",42,23,14,"US President","Stein, Jill","green",FALSE,21341,5742040,20171015,NA
+2012,"Rhode Island","RI",44,15,5,"US President","Obama, Barack H.","democrat",FALSE,279677,446049,20171015,NA
+2012,"Rhode Island","RI",44,15,5,"US President","Romney, Mitt","republican",FALSE,157204,446049,20171015,NA
+2012,"Rhode Island","RI",44,15,5,"US President","Johnson, Gary","libertarian",FALSE,4388,446049,20171015,NA
+2012,"Rhode Island","RI",44,15,5,"US President","Stein, Jill","green",FALSE,2421,446049,20171015,NA
+2012,"Rhode Island","RI",44,15,5,"US President","","",TRUE,1381,446049,20171015,NA
+2012,"Rhode Island","RI",44,15,5,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,430,446049,20171015,NA
+2012,"Rhode Island","RI",44,15,5,"US President","Anderson, Ross Carl """"Rocky""""","justice",FALSE,416,446049,20171015,NA
+2012,"Rhode Island","RI",44,15,5,"US President","Lindsay, Peta","socialism and liberation party",FALSE,132,446049,20171015,NA
+2012,"South Carolina","SC",45,57,48,"US President","Romney, Mitt","republican",FALSE,1071645,1964118,20171015,NA
+2012,"South Carolina","SC",45,57,48,"US President","Obama, Barack H.","democrat",FALSE,865941,1964118,20171015,NA
+2012,"South Carolina","SC",45,57,48,"US President","Johnson, Gary","libertarian",FALSE,16321,1964118,20171015,NA
+2012,"South Carolina","SC",45,57,48,"US President","Stein, Jill","green",FALSE,5446,1964118,20171015,NA
+2012,"South Carolina","SC",45,57,48,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,4765,1964118,20171015,NA
+2012,"South Dakota","SD",46,45,37,"US President","Romney, Mitt","republican",FALSE,210610,363815,20171015,NA
+2012,"South Dakota","SD",46,45,37,"US President","Obama, Barack H.","democrat",FALSE,145039,363815,20171015,NA
+2012,"South Dakota","SD",46,45,37,"US President","Johnson, Gary","libertarian",FALSE,5795,363815,20171015,NA
+2012,"South Dakota","SD",46,45,37,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,2371,363815,20171015,NA
+2012,"Tennessee","TN",47,62,54,"US President","Romney, Mitt","republican",FALSE,1462330,2458577,20171015,NA
+2012,"Tennessee","TN",47,62,54,"US President","Obama, Barack H.","democrat",FALSE,960709,2458577,20171015,NA
+2012,"Tennessee","TN",47,62,54,"US President","","independent",FALSE,23001,2458577,20171015,NA
+2012,"Tennessee","TN",47,62,54,"US President","Stein, Jill","green",FALSE,6515,2458577,20171015,NA
+2012,"Tennessee","TN",47,62,54,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,6022,2458577,20171015,NA
+2012,"Texas","TX",48,74,49,"US President","Romney, Mitt","republican",FALSE,4569843,7993851,20171015,NA
+2012,"Texas","TX",48,74,49,"US President","Obama, Barack H.","democrat",FALSE,3308124,7993851,20171015,NA
+2012,"Texas","TX",48,74,49,"US President","Johnson, Gary","libertarian",FALSE,88580,7993851,20171015,NA
+2012,"Texas","TX",48,74,49,"US President","Stein, Jill","green",FALSE,24657,7993851,20171015,NA
+2012,"Texas","TX",48,74,49,"US President","","",TRUE,2647,7993851,20171015,NA
+2012,"Utah","UT",49,87,67,"US President","Romney, Mitt","republican",FALSE,740600,1017440,20171015,NA
+2012,"Utah","UT",49,87,67,"US President","Obama, Barack H.","democrat",FALSE,251813,1017440,20171015,NA
+2012,"Utah","UT",49,87,67,"US President","Johnson, Gary","libertarian",FALSE,12572,1017440,20171015,NA
+2012,"Utah","UT",49,87,67,"US President","Anderson, Ross Carl """"Rocky""""","justice",FALSE,5335,1017440,20171015,NA
+2012,"Utah","UT",49,87,67,"US President","Stein, Jill","green",FALSE,3817,1017440,20171015,NA
+2012,"Utah","UT",49,87,67,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,2871,1017440,20171015,NA
+2012,"Utah","UT",49,87,67,"US President","","no party affiliation",FALSE,393,1017440,20171015,NA
+2012,"Utah","UT",49,87,67,"US President","","",TRUE,39,1017440,20171015,NA
+2012,"Vermont","VT",50,13,6,"US President","Obama, Barack H.","democrat",FALSE,199239,299290,20171015,NA
+2012,"Vermont","VT",50,13,6,"US President","Romney, Mitt","republican",FALSE,92698,299290,20171015,NA
+2012,"Vermont","VT",50,13,6,"US President","Johnson, Gary","libertarian",FALSE,3487,299290,20171015,NA
+2012,"Vermont","VT",50,13,6,"US President","","",TRUE,2043,299290,20171015,NA
+2012,"Vermont","VT",50,13,6,"US President","Anderson, Ross Carl """"Rocky""""","justice",FALSE,1128,299290,20171015,NA
+2012,"Vermont","VT",50,13,6,"US President","Lindsay, Peta","socialism and liberation party",FALSE,695,299290,20171015,NA
+2012,"Virginia","VA",51,54,40,"US President","Obama, Barack H.","democrat",FALSE,1971820,3854489,20171015,NA
+2012,"Virginia","VA",51,54,40,"US President","Romney, Mitt","republican",FALSE,1822522,3854489,20171015,NA
+2012,"Virginia","VA",51,54,40,"US President","Johnson, Gary","libertarian",FALSE,31216,3854489,20171015,NA
+2012,"Virginia","VA",51,54,40,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,13058,3854489,20171015,NA
+2012,"Virginia","VA",51,54,40,"US President","Stein, Jill","green",FALSE,8627,3854489,20171015,NA
+2012,"Virginia","VA",51,54,40,"US President","","",TRUE,7246,3854489,20171015,NA
+2012,"Washington","WA",53,91,73,"US President","Obama, Barack H.","democrat",FALSE,1755396,3125516,20171015,NA
+2012,"Washington","WA",53,91,73,"US President","Mitt, Romney","republican",FALSE,1290670,3125516,20171015,NA
+2012,"Washington","WA",53,91,73,"US President","Johnson, Gary","libertarian",FALSE,42202,3125516,20171015,NA
+2012,"Washington","WA",53,91,73,"US President","Stein, Jill","green",FALSE,20928,3125516,20171015,NA
+2012,"Washington","WA",53,91,73,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,8851,3125516,20171015,NA
+2012,"Washington","WA",53,91,73,"US President","Anderson, Ross Carl """"Rocky""""","justice",FALSE,4946,3125516,20171015,NA
+2012,"Washington","WA",53,91,73,"US President","Lindsay, Peta","socialism and liberation party",FALSE,1318,3125516,20171015,NA
+2012,"Washington","WA",53,91,73,"US President","Harris, James","socialist workers",FALSE,1205,3125516,20171015,NA
+2012,"West Virginia","WV",54,55,56,"US President","Romney, Mitt","republican",FALSE,417655,670438,20171015,NA
+2012,"West Virginia","WV",54,55,56,"US President","Obama, Barack H.","democrat",FALSE,238269,670438,20171015,NA
+2012,"West Virginia","WV",54,55,56,"US President","Johnson, Gary","libertarian",FALSE,6302,670438,20171015,NA
+2012,"West Virginia","WV",54,55,56,"US President","Stein, Jill","mountain party",FALSE,4406,670438,20171015,NA
+2012,"West Virginia","WV",54,55,56,"US President","","no party affiliation",FALSE,3806,670438,20171015,NA
+2012,"Wisconsin","WI",55,35,25,"US President","Obama, Barack H.","democrat",FALSE,1620985,3071434,20171015,NA
+2012,"Wisconsin","WI",55,35,25,"US President","Romney, Mitt","republican",FALSE,1410966,3071434,20171015,NA
+2012,"Wisconsin","WI",55,35,25,"US President","","independent",FALSE,29383,3071434,20171015,NA
+2012,"Wisconsin","WI",55,35,25,"US President","Scattering","",FALSE,5170,3071434,20171015,NA
+2012,"Wisconsin","WI",55,35,25,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,4930,3071434,20171015,NA
+2012,"Wyoming","WY",56,83,68,"US President","Romney, Mitt","republican",FALSE,170962,250701,20171015,NA
+2012,"Wyoming","WY",56,83,68,"US President","Obama, Barack H.","democrat",FALSE,69286,250701,20171015,NA
+2012,"Wyoming","WY",56,83,68,"US President","Johnson, Gary","libertarian",FALSE,5326,250701,20171015,NA
+2012,"Wyoming","WY",56,83,68,"US President","","",TRUE,2035,250701,20171015,NA
+2012,"Wyoming","WY",56,83,68,"US President","Goode, Virgil Hamlin, Jr.","constitution party",FALSE,1452,250701,20171015,NA
+2012,"Wyoming","WY",56,83,68,"US President","Blank Vote","",FALSE,1367,250701,20171015,NA
+2012,"Wyoming","WY",56,83,68,"US President","Over Vote","",FALSE,273,250701,20171015,NA
+2016,"Alabama","AL",1,63,41,"US President","Trump, Donald J.","republican",FALSE,1318255,2123372,20171015,NA
+2016,"Alabama","AL",1,63,41,"US President","Clinton, Hillary","democrat",FALSE,729547,2123372,20171015,NA
+2016,"Alabama","AL",1,63,41,"US President","Johnson, Gary","libertarian",FALSE,44467,2123372,20171015,NA
+2016,"Alabama","AL",1,63,41,"US President","","",TRUE,21712,2123372,20171015,NA
+2016,"Alabama","AL",1,63,41,"US President","Stein, Jill","green",FALSE,9391,2123372,20171015,NA
+2016,"Alaska","AK",2,94,81,"US President","Trump, Donald J.","republican",FALSE,163387,318608,20171015,NA
+2016,"Alaska","AK",2,94,81,"US President","Clinton, Hillary","democrat",FALSE,116454,318608,20171015,NA
+2016,"Alaska","AK",2,94,81,"US President","Johnson, Gary","libertarian",FALSE,18725,318608,20171015,NA
+2016,"Alaska","AK",2,94,81,"US President","","",TRUE,9201,318608,20171015,NA
+2016,"Alaska","AK",2,94,81,"US President","Stein, Jill","green",FALSE,5735,318608,20171015,NA
+2016,"Alaska","AK",2,94,81,"US President","Castle, Darrell L.","constitution party",FALSE,3866,318608,20171015,NA
+2016,"Alaska","AK",2,94,81,"US President","De La Fuente, Roque """"Rocky""""","no party affiliation",FALSE,1240,318608,20171015,NA
+2016,"Arizona","AZ",4,86,61,"US President","Trump, Donald J.","republican",FALSE,1252401,2573165,20171015,NA
+2016,"Arizona","AZ",4,86,61,"US President","Clinton, Hillary","democrat",FALSE,1161167,2573165,20171015,NA
+2016,"Arizona","AZ",4,86,61,"US President","Johnson, Gary","libertarian",FALSE,106327,2573165,20171015,NA
+2016,"Arizona","AZ",4,86,61,"US President","Stein, Jill","green",FALSE,34345,2573165,20171015,NA
+2016,"Arizona","AZ",4,86,61,"US President","","independent",TRUE,17473,2573165,20171015,NA
+2016,"Arizona","AZ",4,86,61,"US President","Castle, Darrell L.","constitution party",TRUE,1058,2573165,20171015,NA
+2016,"Arizona","AZ",4,86,61,"US President","","no party affiliation",TRUE,311,2573165,20171015,NA
+2016,"Arizona","AZ",4,86,61,"US President","","democrat",TRUE,42,2573165,20171015,NA
+2016,"Arizona","AZ",4,86,61,"US President","De La Fuente, Roque """"Rocky""""","american delta party",TRUE,29,2573165,20171015,NA
+2016,"Arizona","AZ",4,86,61,"US President","Tittle, Sheila """"Samm""""","we the people",TRUE,12,2573165,20171015,NA
+2016,"Arkansas","AR",5,71,42,"US President","Trump, Donald J.","republican",FALSE,684872,1130635,20171015,NA
+2016,"Arkansas","AR",5,71,42,"US President","Clinton, Hillary","democrat",FALSE,380494,1130635,20171015,NA
+2016,"Arkansas","AR",5,71,42,"US President","Johnson, Gary","libertarian",FALSE,29829,1130635,20171015,NA
+2016,"Arkansas","AR",5,71,42,"US President","McMullin, Evan","better for america",FALSE,13255,1130635,20171015,NA
+2016,"Arkansas","AR",5,71,42,"US President","Stein, Jill","green",FALSE,9473,1130635,20171015,NA
+2016,"Arkansas","AR",5,71,42,"US President","Hedges, Jim","prohibition",FALSE,4709,1130635,20171015,NA
+2016,"Arkansas","AR",5,71,42,"US President","Castle, Darrell L.","constitution party",FALSE,4613,1130635,20171015,NA
+2016,"Arkansas","AR",5,71,42,"US President","Kahn, Lynn S.","independent",FALSE,3390,1130635,20171015,NA
+2016,"California","CA",6,93,71,"US President","Clinton, Hillary","democrat",FALSE,8753788,14181595,20171015,NA
+2016,"California","CA",6,93,71,"US President","Trump, Donald J.","republican",FALSE,4483810,14181595,20171015,NA
+2016,"California","CA",6,93,71,"US President","Johnson, Gary","libertarian",FALSE,478500,14181595,20171015,NA
+2016,"California","CA",6,93,71,"US President","Stein, Jill","green",FALSE,278657,14181595,20171015,NA
+2016,"California","CA",6,93,71,"US President","","",TRUE,120739,14181595,20171015,NA
+2016,"California","CA",6,93,71,"US President","La Riva, Gloria Estella","peace & freedom",FALSE,66101,14181595,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Clinton, Hillary","democrat",FALSE,1338870,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Trump, Donald J.","republican",FALSE,1202484,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Johnson, Gary","libertarian",FALSE,144121,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Stein, Jill","green",FALSE,38437,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Scattering","unaffiliated",FALSE,31485,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Castle, Darrell L.","american constitution party",FALSE,11699,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Keniston, Chris","veterans party of america",FALSE,5028,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","De La Fuente, Roque """"Rocky""""","american delta party",FALSE,1255,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Kopitke, Kyle Kenley","independent american",FALSE,1096,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Maldonado, Joseph Allen","independent people of colorado",FALSE,872,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Maturen, Michael A.","american solidarity party",FALSE,862,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Silva, Rod","nutrition party",FALSE,751,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Hoefling, Tom","america's party",FALSE,710,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,531,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Kennedy, Alyson","socialist workers",FALSE,452,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Kotlikoff, Laurence","kotlikoff for president",FALSE,392,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Lyttle, Bradford","nonviolent resistance/pacifist",FALSE,382,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Atwood, Frank","approval voting party",FALSE,337,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Emidio """"Mimi"""", Soltysik","socialist party usa",FALSE,271,2780220,20171015,NA
+2016,"Colorado","CO",8,84,62,"US President","Hedges, James","prohibition",FALSE,185,2780220,20171015,NA
+2016,"Connecticut","CT",9,16,1,"US President","Clinton, Hillary","democrat",FALSE,897572,1644920,20171015,NA
+2016,"Connecticut","CT",9,16,1,"US President","Trump, Donald J.","republican",FALSE,673215,1644920,20171015,NA
+2016,"Connecticut","CT",9,16,1,"US President","Johnson, Gary","libertarian",FALSE,48676,1644920,20171015,NA
+2016,"Connecticut","CT",9,16,1,"US President","Stein, Jill","green",FALSE,22841,1644920,20171015,NA
+2016,"Connecticut","CT",9,16,1,"US President","","",TRUE,2616,1644920,20171015,NA
+2016,"Delaware","DE",10,51,11,"US President","Clinton, Hillary","democrat",FALSE,235603,441590,20171015,NA
+2016,"Delaware","DE",10,51,11,"US President","Trump, Donald J.","republican",FALSE,185127,441590,20171015,NA
+2016,"Delaware","DE",10,51,11,"US President","Johnson, Gary","libertarian",FALSE,14757,441590,20171015,NA
+2016,"Delaware","DE",10,51,11,"US President","Stein, Jill","green",FALSE,6103,441590,20171015,NA
+2016,"District of Columbia","DC",11,53,55,"US President","Clinton, Hillary","democrat",FALSE,282830,312575,20171015,NA
+2016,"District of Columbia","DC",11,53,55,"US President","Trump, Donald J.","republican",FALSE,12723,312575,20171015,NA
+2016,"District of Columbia","DC",11,53,55,"US President","","",TRUE,6551,312575,20171015,NA
+2016,"District of Columbia","DC",11,53,55,"US President","Johnson, Gary","libertarian",FALSE,4906,312575,20171015,NA
+2016,"District of Columbia","DC",11,53,55,"US President","Stein, Jill","green",FALSE,4258,312575,20171015,NA
+2016,"District of Columbia","DC",11,53,55,"US President","Blank Vote","",FALSE,1064,312575,20171015,NA
+2016,"District of Columbia","DC",11,53,55,"US President","Over Vote","",FALSE,243,312575,20171015,NA
+2016,"Florida","FL",12,59,43,"US President","Trump, Donald J.","republican",FALSE,4617886,9420039,20171015,NA
+2016,"Florida","FL",12,59,43,"US President","Clinton, Hillary","democrat",FALSE,4504975,9420039,20171015,NA
+2016,"Florida","FL",12,59,43,"US President","Johnson, Gary","libertarian",FALSE,207043,9420039,20171015,NA
+2016,"Florida","FL",12,59,43,"US President","Stein, Jill","green",FALSE,64399,9420039,20171015,NA
+2016,"Florida","FL",12,59,43,"US President","Castle, Darrell L.","constitution party",FALSE,16475,9420039,20171015,NA
+2016,"Florida","FL",12,59,43,"US President","De La Fuente, Roque """"Rocky""""","reform party",FALSE,9108,9420039,20171015,NA
+2016,"Florida","FL",12,59,43,"US President","","",TRUE,153,9420039,20171015,NA
+2016,"Georgia","GA",13,58,44,"US President","Trump, Donald J.","republican",FALSE,2089104,4114732,20171015,NA
+2016,"Georgia","GA",13,58,44,"US President","Clinton, Hillary","democrat",FALSE,1877963,4114732,20171015,NA
+2016,"Georgia","GA",13,58,44,"US President","Johnson, Gary","libertarian",FALSE,125306,4114732,20171015,NA
+2016,"Georgia","GA",13,58,44,"US President","","",TRUE,22359,4114732,20171015,NA
+2016,"Hawaii","HI",15,95,82,"US President","Clinton, Hillary","democrat",FALSE,266891,437664,20171015,NA
+2016,"Hawaii","HI",15,95,82,"US President","Trump, Donald J.","republican",FALSE,128847,437664,20171015,NA
+2016,"Hawaii","HI",15,95,82,"US President","Johnson, Gary","libertarian",FALSE,15954,437664,20171015,NA
+2016,"Hawaii","HI",15,95,82,"US President","Stein, Jill","green",FALSE,12737,437664,20171015,NA
+2016,"Hawaii","HI",15,95,82,"US President","Blank Vote","",FALSE,8289,437664,20171015,NA
+2016,"Hawaii","HI",15,95,82,"US President","Castle, Darrell L.","constitution party",FALSE,4508,437664,20171015,NA
+2016,"Hawaii","HI",15,95,82,"US President","Over Vote","",FALSE,438,437664,20171015,NA
+2016,"Idaho","ID",16,82,63,"US President","Trump, Donald J.","republican",FALSE,409055,690255,20171015,NA
+2016,"Idaho","ID",16,82,63,"US President","Clinton, Hillary","democrat",FALSE,189765,690255,20171015,NA
+2016,"Idaho","ID",16,82,63,"US President","McMullin, Evan","independent",FALSE,60748,690255,20171015,NA
+2016,"Idaho","ID",16,82,63,"US President","Johnson, Gary","libertarian",FALSE,28331,690255,20171015,NA
+2016,"Idaho","ID",16,82,63,"US President","Castle, Darrell L.","constitution party",FALSE,2356,690255,20171015,NA
+2016,"Illinois","IL",17,33,21,"US President","Clinton, Hillary","democrat",FALSE,3090729,5536424,20171015,NA
+2016,"Illinois","IL",17,33,21,"US President","Trump, Donald J.","republican",FALSE,2146015,5536424,20171015,NA
+2016,"Illinois","IL",17,33,21,"US President","Johnson, Gary","libertarian",FALSE,209596,5536424,20171015,NA
+2016,"Illinois","IL",17,33,21,"US President","Stein, Jill","green",FALSE,76802,5536424,20171015,NA
+2016,"Illinois","IL",17,33,21,"US President","","",TRUE,13282,5536424,20171015,NA
+2016,"Indiana","IN",18,32,22,"US President","Trump, Donald J.","republican",FALSE,1557286,2734958,20171015,NA
+2016,"Indiana","IN",18,32,22,"US President","Clinton, Hillary","democrat",FALSE,1033126,2734958,20171015,NA
+2016,"Indiana","IN",18,32,22,"US President","Johnson, Gary","libertarian",FALSE,133993,2734958,20171015,NA
+2016,"Indiana","IN",18,32,22,"US President","","green",TRUE,7841,2734958,20171015,NA
+2016,"Indiana","IN",18,32,22,"US President","Castle, Darrell L.","constitution party",TRUE,1937,2734958,20171015,NA
+2016,"Indiana","IN",18,32,22,"US President","","independent",TRUE,718,2734958,20171015,NA
+2016,"Indiana","IN",18,32,22,"US President","Emidio """"Mimi"""", Soltysik","socialist party usa",TRUE,57,2734958,20171015,NA
+2016,"Iowa","IA",19,42,31,"US President","Trump, Donald J.","republican",FALSE,800983,1565580,20171015,NA
+2016,"Iowa","IA",19,42,31,"US President","Clinton, Hillary","democrat",FALSE,653669,1565580,20171015,NA
+2016,"Iowa","IA",19,42,31,"US President","Johnson, Gary","libertarian",FALSE,59186,1565580,20171015,NA
+2016,"Iowa","IA",19,42,31,"US President","","",TRUE,17746,1565580,20171015,NA
+2016,"Iowa","IA",19,42,31,"US President","McMullin, Evan","nominated by petition",FALSE,12366,1565580,20171015,NA
+2016,"Iowa","IA",19,42,31,"US President","Stein, Jill","green",FALSE,11479,1565580,20171015,NA
+2016,"Iowa","IA",19,42,31,"US President","Castle, Darrell L.","constitution party",FALSE,5335,1565580,20171015,NA
+2016,"Iowa","IA",19,42,31,"US President","Kahn, Lynn S.","new independent party iowa",FALSE,2247,1565580,20171015,NA
+2016,"Iowa","IA",19,42,31,"US President","Vacek, Dan","legal marijuana now",FALSE,2246,1565580,20171015,NA
+2016,"Iowa","IA",19,42,31,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,323,1565580,20171015,NA
+2016,"Kansas","KS",20,47,32,"US President","Trump, Donald J.","republican",FALSE,671018,1184402,20171015,NA
+2016,"Kansas","KS",20,47,32,"US President","Clinton, Hillary","democrat",FALSE,427005,1184402,20171015,NA
+2016,"Kansas","KS",20,47,32,"US President","Johnson, Gary","libertarian",FALSE,55406,1184402,20171015,NA
+2016,"Kansas","KS",20,47,32,"US President","Stein, Jill","independent",FALSE,23506,1184402,20171015,NA
+2016,"Kansas","KS",20,47,32,"US President","","",TRUE,7467,1184402,20171015,NA
+2016,"Kentucky","KY",21,61,51,"US President","Trump, Donald J.","republican",FALSE,1202971,1924149,20171015,NA
+2016,"Kentucky","KY",21,61,51,"US President","Clinton, Hillary","democrat",FALSE,628854,1924149,20171015,NA
+2016,"Kentucky","KY",21,61,51,"US President","Johnson, Gary","libertarian",FALSE,53752,1924149,20171015,NA
+2016,"Kentucky","KY",21,61,51,"US President","McMullin, Evan","independent",FALSE,22780,1924149,20171015,NA
+2016,"Kentucky","KY",21,61,51,"US President","Stein, Jill","green",FALSE,13913,1924149,20171015,NA
+2016,"Kentucky","KY",21,61,51,"US President","De La Fuente, Roque """"Rocky""""","american delta party",FALSE,1128,1924149,20171015,NA
+2016,"Kentucky","KY",21,61,51,"US President","","",TRUE,751,1924149,20171015,NA
+2016,"Louisiana","LA",22,72,45,"US President","Trump, Donald J.","republican",FALSE,1178638,2029032,20171015,NA
+2016,"Louisiana","LA",22,72,45,"US President","Clinton, Hillary","democrat",FALSE,780154,2029032,20171015,NA
+2016,"Louisiana","LA",22,72,45,"US President","Johnson, Gary","libertarian",FALSE,37978,2029032,20171015,NA
+2016,"Louisiana","LA",22,72,45,"US President","Other","",FALSE,18231,2029032,20171015,NA
+2016,"Louisiana","LA",22,72,45,"US President","Stein, Jill","green",FALSE,14031,2029032,20171015,NA
+2016,"Maine","ME",23,11,2,"US President","Clinton, Hillary","democrat",FALSE,357735,771892,20171015,NA
+2016,"Maine","ME",23,11,2,"US President","Trump, Donald J.","republican",FALSE,335593,771892,20171015,NA
+2016,"Maine","ME",23,11,2,"US President","Johnson, Gary","libertarian",FALSE,38105,771892,20171015,NA
+2016,"Maine","ME",23,11,2,"US President","Blank Vote","",FALSE,23965,771892,20171015,NA
+2016,"Maine","ME",23,11,2,"US President","Stein, Jill","green",FALSE,14251,771892,20171015,NA
+2016,"Maine","ME",23,11,2,"US President","","unenrolled",FALSE,2243,771892,20171015,NA
+2016,"Maryland","MD",24,52,52,"US President","Clinton, Hillary","democrat",FALSE,1677928,2781446,20171015,NA
+2016,"Maryland","MD",24,52,52,"US President","Trump, Donald J.","republican",FALSE,943169,2781446,20171015,NA
+2016,"Maryland","MD",24,52,52,"US President","Johnson, Gary","libertarian",FALSE,79605,2781446,20171015,NA
+2016,"Maryland","MD",24,52,52,"US President","Stein, Jill","green",FALSE,35945,2781446,20171015,NA
+2016,"Maryland","MD",24,52,52,"US President","","",TRUE,33263,2781446,20171015,NA
+2016,"Maryland","MD",24,52,52,"US President","Other","",TRUE,10921,2781446,20171015,NA
+2016,"Maryland","MD",24,52,52,"US President","","no party affiliation",TRUE,278,2781446,20171015,NA
+2016,"Maryland","MD",24,52,52,"US President","Trump, Donald J.","republican",TRUE,259,2781446,20171015,NA
+2016,"Maryland","MD",24,52,52,"US President","Clinton, Hillary","democrat",TRUE,78,2781446,20171015,NA
+2016,"Massachusetts","MA",25,14,3,"US President","Clinton, Hillary","democrat",FALSE,1995196,3378821,20171015,NA
+2016,"Massachusetts","MA",25,14,3,"US President","Trump, Donald J.","republican",FALSE,1090893,3378821,20171015,NA
+2016,"Massachusetts","MA",25,14,3,"US President","Johnson, Gary","libertarian",FALSE,138018,3378821,20171015,NA
+2016,"Massachusetts","MA",25,14,3,"US President","Blank Vote","",FALSE,53775,3378821,20171015,NA
+2016,"Massachusetts","MA",25,14,3,"US President","Other","",FALSE,50488,3378821,20171015,NA
+2016,"Massachusetts","MA",25,14,3,"US President","Stein, Jill","green",FALSE,47661,3378821,20171015,NA
+2016,"Massachusetts","MA",25,14,3,"US President","","",TRUE,2790,3378821,20171015,NA
+2016,"Michigan","MI",26,34,23,"US President","Trump, Donald J.","republican",FALSE,2279543,4799284,20171015,NA
+2016,"Michigan","MI",26,34,23,"US President","Clinton, Hillary","democrat",FALSE,2268839,4799284,20171015,NA
+2016,"Michigan","MI",26,34,23,"US President","Johnson, Gary","libertarian",FALSE,172136,4799284,20171015,NA
+2016,"Michigan","MI",26,34,23,"US President","Stein, Jill","green",FALSE,51463,4799284,20171015,NA
+2016,"Michigan","MI",26,34,23,"US President","Castle, Darrell L.","u.s. taxpayers party",FALSE,16139,4799284,20171015,NA
+2016,"Michigan","MI",26,34,23,"US President","","",TRUE,8955,4799284,20171015,NA
+2016,"Michigan","MI",26,34,23,"US President","Emidio """"Mimi"""", Soltysik","natural law",FALSE,2209,4799284,20171015,NA
+2016,"Minnesota","MN",27,41,33,"US President","Clinton, Hillary","democrat",FALSE,1367705,2944782,20171015,NA
+2016,"Minnesota","MN",27,41,33,"US President","Trump, Donald J.","republican",FALSE,1322949,2944782,20171015,NA
+2016,"Minnesota","MN",27,41,33,"US President","Johnson, Gary","libertarian",FALSE,112972,2944782,20171015,NA
+2016,"Minnesota","MN",27,41,33,"US President","McMullin, Evan","independence",FALSE,53075,2944782,20171015,NA
+2016,"Minnesota","MN",27,41,33,"US President","Stein, Jill","green",FALSE,36986,2944782,20171015,NA
+2016,"Minnesota","MN",27,41,33,"US President","","",TRUE,27247,2944782,20171015,NA
+2016,"Minnesota","MN",27,41,33,"US President","Vacek, Dan","legal marijuana now",FALSE,11291,2944782,20171015,NA
+2016,"Minnesota","MN",27,41,33,"US President","Castle, Darrell L.","constitution party",FALSE,9456,2944782,20171015,NA
+2016,"Minnesota","MN",27,41,33,"US President","Kennedy, Alyson","socialist workers",FALSE,1671,2944782,20171015,NA
+2016,"Minnesota","MN",27,41,33,"US President","De La Fuente, Roque """"Rocky""""","american delta party",FALSE,1430,2944782,20171015,NA
+2016,"Mississippi","MS",28,64,46,"US President","Trump, Donald J.","republican",FALSE,700714,1209357,20171015,NA
+2016,"Mississippi","MS",28,64,46,"US President","Clinton, Hillary","democrat",FALSE,485131,1209357,20171015,NA
+2016,"Mississippi","MS",28,64,46,"US President","Johnson, Gary","libertarian",FALSE,14435,1209357,20171015,NA
+2016,"Mississippi","MS",28,64,46,"US President","Castle, Darrell L.","constitution party",FALSE,3987,1209357,20171015,NA
+2016,"Mississippi","MS",28,64,46,"US President","Stein, Jill","green",FALSE,3731,1209357,20171015,NA
+2016,"Mississippi","MS",28,64,46,"US President","Hedges, James","prohibition",FALSE,715,1209357,20171015,NA
+2016,"Mississippi","MS",28,64,46,"US President","De La Fuente, Roque """"Rocky""""","american delta party",FALSE,644,1209357,20171015,NA
+2016,"Missouri","MO",29,43,34,"US President","Trump, Donald J.","republican",FALSE,1594511,2808605,20171015,NA
+2016,"Missouri","MO",29,43,34,"US President","Clinton, Hillary","democrat",FALSE,1071068,2808605,20171015,NA
+2016,"Missouri","MO",29,43,34,"US President","Johnson, Gary","libertarian",FALSE,97359,2808605,20171015,NA
+2016,"Missouri","MO",29,43,34,"US President","Stein, Jill","green",FALSE,25419,2808605,20171015,NA
+2016,"Missouri","MO",29,43,34,"US President","Castle, Darrell L.","constitution party",FALSE,13092,2808605,20171015,NA
+2016,"Missouri","MO",29,43,34,"US President","","",TRUE,7156,2808605,20171015,NA
+2016,"Montana","MT",30,81,64,"US President","Trump, Donald J.","republican",FALSE,279240,494526,20171015,NA
+2016,"Montana","MT",30,81,64,"US President","Clinton, Hillary","democrat",FALSE,177709,494526,20171015,NA
+2016,"Montana","MT",30,81,64,"US President","Johnson, Gary","libertarian",FALSE,28037,494526,20171015,NA
+2016,"Montana","MT",30,81,64,"US President","Stein, Jill","green",FALSE,7970,494526,20171015,NA
+2016,"Montana","MT",30,81,64,"US President","De La Fuente, Roque """"Rocky""""","american delta party",FALSE,1570,494526,20171015,NA
+2016,"Nebraska","NE",31,46,35,"US President","Trump, Donald J.","republican",FALSE,495961,844227,20171015,NA
+2016,"Nebraska","NE",31,46,35,"US President","Clinton, Hillary","democrat",FALSE,284494,844227,20171015,NA
+2016,"Nebraska","NE",31,46,35,"US President","Johnson, Gary","libertarian",FALSE,38946,844227,20171015,NA
+2016,"Nebraska","NE",31,46,35,"US President","","",TRUE,16051,844227,20171015,NA
+2016,"Nebraska","NE",31,46,35,"US President","Stein, Jill","nominated by petition",FALSE,8775,844227,20171015,NA
+2016,"Nevada","NV",32,88,65,"US President","Clinton, Hillary","democrat",FALSE,539260,1125385,20171015,NA
+2016,"Nevada","NV",32,88,65,"US President","Trump, Donald J.","republican",FALSE,512058,1125385,20171015,NA
+2016,"Nevada","NV",32,88,65,"US President","Johnson, Gary","libertarian",FALSE,37384,1125385,20171015,NA
+2016,"Nevada","NV",32,88,65,"US President","None Of The Above","",FALSE,28863,1125385,20171015,NA
+2016,"Nevada","NV",32,88,65,"US President","Kopitke, Kyle Kenley","independent american",FALSE,5268,1125385,20171015,NA
+2016,"Nevada","NV",32,88,65,"US President","De La Fuente, Roque """"Rocky""""","no party affiliation",FALSE,2552,1125385,20171015,NA
+2016,"New Hampshire","NH",33,12,4,"US President","Clinton, Hillary","democrat",FALSE,348526,744296,20171015,NA
+2016,"New Hampshire","NH",33,12,4,"US President","Trump, Donald J.","republican",FALSE,345790,744296,20171015,NA
+2016,"New Hampshire","NH",33,12,4,"US President","Johnson, Gary","libertarian",FALSE,30777,744296,20171015,NA
+2016,"New Hampshire","NH",33,12,4,"US President","","",TRUE,9618,744296,20171015,NA
+2016,"New Hampshire","NH",33,12,4,"US President","Stein, Jill","green",FALSE,6496,744296,20171015,NA
+2016,"New Hampshire","NH",33,12,4,"US President","Scattering","",TRUE,2411,744296,20171015,NA
+2016,"New Hampshire","NH",33,12,4,"US President","De La Fuente, Roque """"Rocky""""","american delta party",FALSE,678,744296,20171015,NA
+2016,"New Jersey","NJ",34,22,12,"US President","Clinton, Hillary","democrat",FALSE,2148278,3874046,20171015,NA
+2016,"New Jersey","NJ",34,22,12,"US President","Trump, Donald J.","republican",FALSE,1601933,3874046,20171015,NA
+2016,"New Jersey","NJ",34,22,12,"US President","Johnson, Gary","libertarian",FALSE,72477,3874046,20171015,NA
+2016,"New Jersey","NJ",34,22,12,"US President","Stein, Jill","green",FALSE,37772,3874046,20171015,NA
+2016,"New Jersey","NJ",34,22,12,"US President","Castle, Darrell L.","constitution party",FALSE,6161,3874046,20171015,NA
+2016,"New Jersey","NJ",34,22,12,"US President","Kennedy, Alyson","socialist workers",FALSE,2156,3874046,20171015,NA
+2016,"New Jersey","NJ",34,22,12,"US President","De La Fuente, Roque """"Rocky""""","american delta party",FALSE,1838,3874046,20171015,NA
+2016,"New Jersey","NJ",34,22,12,"US President","Moorehead, Monica","workers world party",FALSE,1749,3874046,20171015,NA
+2016,"New Jersey","NJ",34,22,12,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,1682,3874046,20171015,NA
+2016,"New Mexico","NM",35,85,66,"US President","Clinton, Hillary","democrat",FALSE,385234,798319,20171015,NA
+2016,"New Mexico","NM",35,85,66,"US President","Trump, Donald J.","republican",FALSE,319667,798319,20171015,NA
+2016,"New Mexico","NM",35,85,66,"US President","Johnson, Gary","libertarian",FALSE,74541,798319,20171015,NA
+2016,"New Mexico","NM",35,85,66,"US President","Stein, Jill","green",FALSE,9879,798319,20171015,NA
+2016,"New Mexico","NM",35,85,66,"US President","McMullin, Evan","better for america",FALSE,5825,798319,20171015,NA
+2016,"New Mexico","NM",35,85,66,"US President","Castle, Darrell L.","constitution party",FALSE,1514,798319,20171015,NA
+2016,"New Mexico","NM",35,85,66,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,1184,798319,20171015,NA
+2016,"New Mexico","NM",35,85,66,"US President","De La Fuente, Roque """"Rocky""""","american delta party",FALSE,475,798319,20171015,NA
+2016,"New York","NY",36,21,13,"US President","Clinton, Hillary","democrat",FALSE,4379789,7802084,20171015,NA
+2016,"New York","NY",36,21,13,"US President","Trump, Donald J.","republican",FALSE,2527142,7802084,20171015,NA
+2016,"New York","NY",36,21,13,"US President","Trump, Donald J.","conservative",FALSE,292392,7802084,20171015,NA
+2016,"New York","NY",36,21,13,"US President","Clinton, Hillary","working families",FALSE,140041,7802084,20171015,NA
+2016,"New York","NY",36,21,13,"US President","Johnson, Gary","independence",FALSE,119156,7802084,20171015,NA
+2016,"New York","NY",36,21,13,"US President","Stein, Jill","green",FALSE,107934,7802084,20171015,NA
+2016,"New York","NY",36,21,13,"US President","Blank Vote","",FALSE,77179,7802084,20171015,NA
+2016,"New York","NY",36,21,13,"US President","Johnson, Gary","libertarian",FALSE,57442,7802084,20171015,NA
+2016,"New York","NY",36,21,13,"US President","Scattering","",FALSE,48447,7802084,20171015,NA
+2016,"New York","NY",36,21,13,"US President","Clinton, Hillary","women's equality",FALSE,36294,7802084,20171015,NA
+2016,"New York","NY",36,21,13,"US President","","",TRUE,12816,7802084,20171015,NA
+2016,"New York","NY",36,21,13,"US President","Void Vote","",FALSE,3452,7802084,20171015,NA
+2016,"North Carolina","NC",37,56,47,"US President","Trump, Donald J.","republican",FALSE,2362631,4741564,20171015,NA
+2016,"North Carolina","NC",37,56,47,"US President","Clinton, Hillary","democrat",FALSE,2189316,4741564,20171015,NA
+2016,"North Carolina","NC",37,56,47,"US President","Johnson, Gary","libertarian",FALSE,130126,4741564,20171015,NA
+2016,"North Carolina","NC",37,56,47,"US President","Scattering","",TRUE,47386,4741564,20171015,NA
+2016,"North Carolina","NC",37,56,47,"US President","","",TRUE,12105,4741564,20171015,NA
+2016,"North Dakota","ND",38,44,36,"US President","Trump, Donald J.","republican",FALSE,216794,344360,20171015,NA
+2016,"North Dakota","ND",38,44,36,"US President","Clinton, Hillary","democrat",FALSE,93758,344360,20171015,NA
+2016,"North Dakota","ND",38,44,36,"US President","Johnson, Gary","libertarian",FALSE,21434,344360,20171015,NA
+2016,"North Dakota","ND",38,44,36,"US President","","",TRUE,6397,344360,20171015,NA
+2016,"North Dakota","ND",38,44,36,"US President","Stein, Jill","green",FALSE,3780,344360,20171015,NA
+2016,"North Dakota","ND",38,44,36,"US President","Castle, Darrell L.","constitution party",FALSE,1833,344360,20171015,NA
+2016,"North Dakota","ND",38,44,36,"US President","De La Fuente, Roque """"Rocky""""","american delta party",FALSE,364,344360,20171015,NA
+2016,"Ohio","OH",39,31,24,"US President","Trump, Donald J.","republican",FALSE,2841005,5496487,20171015,NA
+2016,"Ohio","OH",39,31,24,"US President","Clinton, Hillary","democrat",FALSE,2394164,5496487,20171015,NA
+2016,"Ohio","OH",39,31,24,"US President","","no party affiliation",FALSE,198733,5496487,20171015,NA
+2016,"Ohio","OH",39,31,24,"US President","Stein, Jill","green",FALSE,46271,5496487,20171015,NA
+2016,"Ohio","OH",39,31,24,"US President","","",TRUE,16314,5496487,20171015,NA
+2016,"Oklahoma","OK",40,73,53,"US President","Trump, Donald J.","republican",FALSE,949136,1452992,20171015,NA
+2016,"Oklahoma","OK",40,73,53,"US President","Clinton, Hillary","democrat",FALSE,420375,1452992,20171015,NA
+2016,"Oklahoma","OK",40,73,53,"US President","Johnson, Gary","libertarian",FALSE,83481,1452992,20171015,NA
+2016,"Oregon","OR",41,92,72,"US President","Clinton, Hillary","democrat",FALSE,1002106,2001336,20171015,NA
+2016,"Oregon","OR",41,92,72,"US President","Trump, Donald J.","republican",FALSE,782403,2001336,20171015,NA
+2016,"Oregon","OR",41,92,72,"US President","Johnson, Gary","libertarian",FALSE,94231,2001336,20171015,NA
+2016,"Oregon","OR",41,92,72,"US President","Other","",FALSE,72594,2001336,20171015,NA
+2016,"Oregon","OR",41,92,72,"US President","Stein, Jill","green",FALSE,50002,2001336,20171015,NA
+2016,"Pennsylvania","PA",42,23,14,"US President","Trump, Donald J.","republican",FALSE,2970733,6115402,20171015,NA
+2016,"Pennsylvania","PA",42,23,14,"US President","Clinton, Hillary","democrat",FALSE,2926441,6115402,20171015,NA
+2016,"Pennsylvania","PA",42,23,14,"US President","Johnson, Gary","libertarian",FALSE,146715,6115402,20171015,NA
+2016,"Pennsylvania","PA",42,23,14,"US President","Stein, Jill","green",FALSE,49941,6115402,20171015,NA
+2016,"Pennsylvania","PA",42,23,14,"US President","Castle, Darrell L.","constitution party",FALSE,21572,6115402,20171015,NA
+2016,"Rhode Island","RI",44,15,5,"US President","Clinton, Hillary","democrat",FALSE,252525,464144,20171015,NA
+2016,"Rhode Island","RI",44,15,5,"US President","Trump, Donald J.","republican",FALSE,180543,464144,20171015,NA
+2016,"Rhode Island","RI",44,15,5,"US President","Johnson, Gary","libertarian",FALSE,14746,464144,20171015,NA
+2016,"Rhode Island","RI",44,15,5,"US President","","",TRUE,9439,464144,20171015,NA
+2016,"Rhode Island","RI",44,15,5,"US President","Stein, Jill","green",FALSE,6220,464144,20171015,NA
+2016,"Rhode Island","RI",44,15,5,"US President","De La Fuente, Roque """"Rocky""""","american delta party",FALSE,671,464144,20171015,NA
+2016,"South Carolina","SC",45,57,48,"US President","Trump, Donald J.","republican",FALSE,1155389,2103027,20171015,NA
+2016,"South Carolina","SC",45,57,48,"US President","Clinton, Hillary","democrat",FALSE,855373,2103027,20171015,NA
+2016,"South Carolina","SC",45,57,48,"US President","Johnson, Gary","libertarian",FALSE,49204,2103027,20171015,NA
+2016,"South Carolina","SC",45,57,48,"US President","McMullin, Evan","independence",FALSE,21016,2103027,20171015,NA
+2016,"South Carolina","SC",45,57,48,"US President","Stein, Jill","green",FALSE,13034,2103027,20171015,NA
+2016,"South Carolina","SC",45,57,48,"US President","Castle, Darrell L.","constitution party",FALSE,5765,2103027,20171015,NA
+2016,"South Carolina","SC",45,57,48,"US President","Skewes, Peter","american",FALSE,3246,2103027,20171015,NA
+2016,"South Dakota","SD",46,45,37,"US President","Trump, Donald J.","republican",FALSE,227721,370093,20171015,NA
+2016,"South Dakota","SD",46,45,37,"US President","Clinton, Hillary","democrat",FALSE,117458,370093,20171015,NA
+2016,"South Dakota","SD",46,45,37,"US President","Johnson, Gary","libertarian",FALSE,20850,370093,20171015,NA
+2016,"South Dakota","SD",46,45,37,"US President","Castle, Darrell L.","constitution party",FALSE,4064,370093,20171015,NA
+2016,"Tennessee","TN",47,62,54,"US President","Trump, Donald J.","republican",FALSE,1522925,2508027,20171015,NA
+2016,"Tennessee","TN",47,62,54,"US President","Clinton, Hillary","democrat",FALSE,870695,2508027,20171015,NA
+2016,"Tennessee","TN",47,62,54,"US President","","independent",FALSE,100618,2508027,20171015,NA
+2016,"Tennessee","TN",47,62,54,"US President","","",TRUE,13789,2508027,20171015,NA
+2016,"Texas","TX",48,74,49,"US President","Trump, Donald J.","republican",FALSE,4685047,8969226,20171015,NA
+2016,"Texas","TX",48,74,49,"US President","Clinton, Hillary","democrat",FALSE,3877868,8969226,20171015,NA
+2016,"Texas","TX",48,74,49,"US President","Johnson, Gary","libertarian",FALSE,283492,8969226,20171015,NA
+2016,"Texas","TX",48,74,49,"US President","Stein, Jill","green",FALSE,71558,8969226,20171015,NA
+2016,"Texas","TX",48,74,49,"US President","","",TRUE,51261,8969226,20171015,NA
+2016,"Utah","UT",49,87,67,"US President","Trump, Donald J.","republican",FALSE,515211,1131317,20171015,NA
+2016,"Utah","UT",49,87,67,"US President","Clinton, Hillary","democrat",FALSE,310674,1131317,20171015,NA
+2016,"Utah","UT",49,87,67,"US President","McMullin, Evan","no party affiliation",FALSE,255060,1131317,20171015,NA
+2016,"Utah","UT",49,87,67,"US President","Johnson, Gary","libertarian",FALSE,39608,1131317,20171015,NA
+2016,"Utah","UT",49,87,67,"US President","Castle, Darrell L.","constitution party",FALSE,8032,1131317,20171015,NA
+2016,"Utah","UT",49,87,67,"US President","Kopitke, Kyle Kenley","independent american",FALSE,2732,1131317,20171015,NA
+2016,"Vermont","VT",50,13,6,"US President","Clinton, Hillary","democrat",FALSE,178573,320467,20171015,NA
+2016,"Vermont","VT",50,13,6,"US President","Trump, Donald J.","republican",FALSE,95369,320467,20171015,NA
+2016,"Vermont","VT",50,13,6,"US President","","",TRUE,22899,320467,20171015,NA
+2016,"Vermont","VT",50,13,6,"US President","Johnson, Gary","libertarian",FALSE,10078,320467,20171015,NA
+2016,"Vermont","VT",50,13,6,"US President","Stein, Jill","green",FALSE,6758,320467,20171015,NA
+2016,"Vermont","VT",50,13,6,"US President","Blank Vote","",FALSE,4574,320467,20171015,NA
+2016,"Vermont","VT",50,13,6,"US President","De La Fuente, Roque """"Rocky""""","independent",FALSE,1063,320467,20171015,NA
+2016,"Vermont","VT",50,13,6,"US President","Void Vote","",FALSE,826,320467,20171015,NA
+2016,"Vermont","VT",50,13,6,"US President","La Riva, Gloria Estella","liberty union party",FALSE,327,320467,20171015,NA
+2016,"Virginia","VA",51,54,40,"US President","Clinton, Hillary","democrat",FALSE,1981473,3982752,20171015,NA
+2016,"Virginia","VA",51,54,40,"US President","Trump, Donald J.","republican",FALSE,1769443,3982752,20171015,NA
+2016,"Virginia","VA",51,54,40,"US President","Johnson, Gary","libertarian",FALSE,118274,3982752,20171015,NA
+2016,"Virginia","VA",51,54,40,"US President","McMullin, Evan","independent",FALSE,54054,3982752,20171015,NA
+2016,"Virginia","VA",51,54,40,"US President","","",TRUE,31870,3982752,20171015,NA
+2016,"Virginia","VA",51,54,40,"US President","Stein, Jill","green",FALSE,27638,3982752,20171015,NA
+2016,"Washington","WA",53,91,73,"US President","Clinton, Hillary","democrat",FALSE,1742718,3317019,20171015,NA
+2016,"Washington","WA",53,91,73,"US President","Trump, Donald J.","republican",FALSE,1221747,3317019,20171015,NA
+2016,"Washington","WA",53,91,73,"US President","Johnson, Gary","libertarian",FALSE,160879,3317019,20171015,NA
+2016,"Washington","WA",53,91,73,"US President","","",TRUE,107805,3317019,20171015,NA
+2016,"Washington","WA",53,91,73,"US President","Stein, Jill","green",FALSE,58417,3317019,20171015,NA
+2016,"Washington","WA",53,91,73,"US President","Castle, Darrell L.","constitution party",FALSE,17623,3317019,20171015,NA
+2016,"Washington","WA",53,91,73,"US President","Kennedy, Alyson","socialist workers",FALSE,4307,3317019,20171015,NA
+2016,"Washington","WA",53,91,73,"US President","La Riva, Gloria Estella","socialism and liberation party",FALSE,3523,3317019,20171015,NA
+2016,"West Virginia","WV",54,55,56,"US President","Trump, Donald J.","republican",FALSE,489371,713051,20171015,NA
+2016,"West Virginia","WV",54,55,56,"US President","Clinton, Hillary","democrat",FALSE,188794,713051,20171015,NA
+2016,"West Virginia","WV",54,55,56,"US President","Johnson, Gary","libertarian",FALSE,23004,713051,20171015,NA
+2016,"West Virginia","WV",54,55,56,"US President","Stein, Jill","green",FALSE,8075,713051,20171015,NA
+2016,"West Virginia","WV",54,55,56,"US President","Castle, Darrell L.","constitution party",FALSE,3807,713051,20171015,NA
+2016,"Wisconsin","WI",55,35,25,"US President","Trump, Donald J.","republican",FALSE,1405284,2976150,20171015,NA
+2016,"Wisconsin","WI",55,35,25,"US President","Clinton, Hillary","democrat",FALSE,1382536,2976150,20171015,NA
+2016,"Wisconsin","WI",55,35,25,"US President","Johnson, Gary","libertarian",FALSE,106674,2976150,20171015,NA
+2016,"Wisconsin","WI",55,35,25,"US President","Stein, Jill","green",FALSE,31072,2976150,20171015,NA
+2016,"Wisconsin","WI",55,35,25,"US President","Scattering","",FALSE,22764,2976150,20171015,NA
+2016,"Wisconsin","WI",55,35,25,"US President","","",TRUE,12386,2976150,20171015,NA
+2016,"Wisconsin","WI",55,35,25,"US President","Castle, Darrell L.","constitution party",FALSE,12162,2976150,20171015,NA
+2016,"Wisconsin","WI",55,35,25,"US President","Moorehead, Monica","workers world party",FALSE,1770,2976150,20171015,NA
+2016,"Wisconsin","WI",55,35,25,"US President","De La Fuente, Roque """"Rocky""""","american delta party",FALSE,1502,2976150,20171015,NA
+2016,"Wyoming","WY",56,83,68,"US President","Trump, Donald J.","republican",FALSE,174419,258788,20171015,NA
+2016,"Wyoming","WY",56,83,68,"US President","Clinton, Hillary","democrat",FALSE,55973,258788,20171015,NA
+2016,"Wyoming","WY",56,83,68,"US President","Johnson, Gary","libertarian",FALSE,13287,258788,20171015,NA
+2016,"Wyoming","WY",56,83,68,"US President","","",TRUE,6904,258788,20171015,NA
+2016,"Wyoming","WY",56,83,68,"US President","","independent",FALSE,3224,258788,20171015,NA
+2016,"Wyoming","WY",56,83,68,"US President","Blank Vote","",FALSE,2661,258788,20171015,NA
+2016,"Wyoming","WY",56,83,68,"US President","Castle, Darrell L.","constitution party",FALSE,2042,258788,20171015,NA
+2016,"Wyoming","WY",56,83,68,"US President","Over Vote","",FALSE,278,258788,20171015,NA

--- a/lab3/scripts/pres_2016.csv
+++ b/lab3/scripts/pres_2016.csv
@@ -1,0 +1,52 @@
+year,state,party,percent_vote,
+2016,Alabama,R,62.08
+2016,Alaska,R,51.28
+2016,Arizona,R,48.67
+2016,Arkansas,R,60.57
+2016,California,D,61.73
+2016,Colorado,D,48.16
+2016,Connecticut,D,54.57
+2016,Delaware,D,53.35
+2016,District of Columbia,D,90.48
+2016,Florida,R,49.02
+2016,Georgia,R,50.77
+2016,Hawaii,D,60.98
+2016,Idaho,R,59.26
+2016,Illinois,D,55.83
+2016,Indiana,R,56.94
+2016,Iowa,R,51.16
+2016,Kansas,R,56.65
+2016,Kentucky,R,62.52
+2016,Louisiana,R,58.09
+2016,Maine,D,46.35
+2016,Maryland,D,60.33
+2016,Massachusetts,D,59.05
+2016,Michigan,R,47.5
+2016,Minnesota,D,46.45
+2016,Mississippi,R,57.94
+2016,Missouri,R,56.77
+2016,Montana,R,56.47
+2016,Nebraska,R,58.75
+2016,Nevada,D,47.92
+2016,New Hampshire,D,46.83
+2016,New Jersey,D,55.45
+2016,New Mexico,D,48.26
+2016,New York,D,56.14
+2016,North Carolina,R,49.83
+2016,North Dakota,R,62.96
+2016,Ohio,R,51.69
+2016,Oklahoma,R,65.32
+2016,Oregon,D,50.07
+2016,Pennsylvania,R,48.58
+2016,Rhode Island,D,54.41
+2016,South Carolina,R,54.94
+2016,South Dakota,R,61.53
+2016,Tennessee,R,60.72
+2016,Texas,R,52.23
+2016,Utah,R,45.54
+2016,Vermont,D,55.72
+2016,Virginia,D,49.75
+2016,Washington,D,52.54
+2016,West Virginia,R,68.63
+2016,Wisconsin,R,47.22
+2016,Wyoming,R,67.4


### PR DESCRIPTION
Scripts to create the presidential party votes by state for the 2016 U.S. presidential election.